### PR TITLE
Mark reactivex packages as optional in OSGi metadata

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -196,12 +196,16 @@
             io.vertx.ext.auth,\
             io.vertx.ext.auth.*;resolution:=optional,\
             io.vertx.lang.rxjava.*;resolution:=optional,\
+            io.vertx.lang.reactivex.*;resolution:=optional,\
             io.vertx.lang.groovy.*;resolution:=optional,\
             io.vertx.codegen.annotations;resolution:=optional,\
             io.vertx.rx.java;resolution:=optional,\
             io.vertx.rxjava.core.*;resolution:=optional,\
             io.vertx.rxjava.ext.auth.*;resolution:=optional,\
+            io.vertx.reactivex;resolution:=optional,\
+            io.vertx.reactivex.core.*;resolution:=optional,\
             rx.*;resolution:=optional,\
+            io.reactivex.*;resolution:=optional,\
             *
           -exportcontents: !*impl, !examples, *
           ]]></bnd>

--- a/pom.xml
+++ b/pom.xml
@@ -193,15 +193,12 @@
             org.codehaus.groovy.*;resolution:=optional,\
             kotlin.*;resolution:=optional,\
             io.vertx.groovy.*;resolution:=optional,\
-            io.vertx.ext.auth,\
-            io.vertx.ext.auth.*;resolution:=optional,\
             io.vertx.lang.rxjava.*;resolution:=optional,\
             io.vertx.lang.reactivex.*;resolution:=optional,\
             io.vertx.lang.groovy.*;resolution:=optional,\
             io.vertx.codegen.annotations;resolution:=optional,\
             io.vertx.rx.java;resolution:=optional,\
             io.vertx.rxjava.core.*;resolution:=optional,\
-            io.vertx.rxjava.ext.auth.*;resolution:=optional,\
             io.vertx.reactivex;resolution:=optional,\
             io.vertx.reactivex.core.*;resolution:=optional,\
             rx.*;resolution:=optional,\


### PR DESCRIPTION
When trying the `3.5.0.Beta1` bundle, it was unable to deploy when rxjava2 was missing.

I've added `resolution:=optional` to theses new imported packages (just like what was done for other languages).

I've also discovered that `io.vertx.ext.auth` was actually never used in this module, but import was required. I've simply removed the lines related to this group of packages.