### PR TITLE
Improve the logging when connections fail

### DIFF
--- a/src/main/java/io/vertx/mqtt/impl/MqttClientImpl.java
+++ b/src/main/java/io/vertx/mqtt/impl/MqttClientImpl.java
@@ -825,7 +825,7 @@ public class MqttClientImpl implements MqttClient {
           this.connectHandler.handle(Future.succeededFuture(msg));
         } else {
           MqttConnectionException exception = new MqttConnectionException(msg.code());
-          log.error("Connection refused by the server");
+          log.error(String.format("Connection refused by the server - code: %s", msg.code()));
           this.connectHandler.handle(Future.failedFuture(exception));
         }
       }


### PR DESCRIPTION
This changed does lower the log output when a connection fails to WARN
as the application can always handle this properly. Also is the failed
state forwarded to the application specific part, which may decide if
this is an actual error.

Also the error code get added to the log message.