### PR TITLE
#66: Fix missing callback when TCP connect fails

### DIFF
--- a/src/main/java/io/vertx/mqtt/impl/MqttClientImpl.java
+++ b/src/main/java/io/vertx/mqtt/impl/MqttClientImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 Red Hat Inc.
+ * Copyright 2016, 2017 Red Hat Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -165,6 +165,10 @@ public class MqttClientImpl implements MqttClient {
         log.error(String.format("Can't connect to %s:%d", host, port), done.cause());
         if (connectHandler != null) {
           connectHandler.handle(Future.failedFuture(done.cause()));
+        }
+        final Handler<Void> closeHandler = this.closeHandler;
+        if (closeHandler != null) {
+            closeHandler.handle(null);
         }
       } else {
         log.info(String.format("Connection with %s:%d established successfully", host, port));


### PR DESCRIPTION
When the TCP connect fails, then there is no notification via the
closeHandler. On the other side listening to the connect future for
errors notifies you twice of an error (via closeHandler and via future)
in cases where the TCP connect succeeded, but a CONACK with an error
is received.

This change adds a call to the closeHandler in case the TCP connect
fails, so consumers can solely rely on the closeHandler for failed
connection attempts and can re-trigger a connection, thus implementing
"auto reconnect".

Signed-off-by: Jens Reimann <jreimann@redhat.com>