### PR TITLE
Use 'publishReceived' instead of 'publishRelease'

### DIFF
--- a/src/main/asciidoc/groovy/index.adoc
+++ b/src/main/asciidoc/groovy/index.adoc
@@ -170,7 +170,7 @@ endpoint.publishHandler({ message ->
   if (message.qosLevel() == MqttQoS.AT_LEAST_ONCE) {
     endpoint.publishAcknowledge(message.messageId())
   } else if (message.qosLevel() == MqttQoS.EXACTLY_ONCE) {
-    endpoint.publishRelease(message.messageId())
+    endpoint.publishReceived(message.messageId())
   }
 
 }).publishReleaseHandler({ messageId ->

--- a/src/main/asciidoc/java/index.adoc
+++ b/src/main/asciidoc/java/index.adoc
@@ -226,7 +226,7 @@ endpoint.publishHandler(message -> {
   if (message.qosLevel() == MqttQoS.AT_LEAST_ONCE) {
     endpoint.publishAcknowledge(message.messageId());
   } else if (message.qosLevel() == MqttQoS.EXACTLY_ONCE) {
-    endpoint.publishRelease(message.messageId());
+    endpoint.publishReceived(message.messageId());
   }
 
 }).publishReleaseHandler(messageId -> {

--- a/src/main/asciidoc/js/index.adoc
+++ b/src/main/asciidoc/js/index.adoc
@@ -170,7 +170,7 @@ endpoint.publishHandler(function (message) {
   if (message.qosLevel() === 'AT_LEAST_ONCE') {
     endpoint.publishAcknowledge(message.messageId());
   } else if (message.qosLevel() === 'EXACTLY_ONCE') {
-    endpoint.publishRelease(message.messageId());
+    endpoint.publishReceived(message.messageId());
   }
 
 }).publishReleaseHandler(function (messageId) {

--- a/src/main/asciidoc/kotlin/index.adoc
+++ b/src/main/asciidoc/kotlin/index.adoc
@@ -170,7 +170,7 @@ endpoint.publishHandler({ message ->
   if (message.qosLevel() == MqttQoS.AT_LEAST_ONCE) {
     endpoint.publishAcknowledge(message.messageId())
   } else if (message.qosLevel() == MqttQoS.EXACTLY_ONCE) {
-    endpoint.publishRelease(message.messageId())
+    endpoint.publishReceived(message.messageId())
   }
 
 }).publishReleaseHandler({ messageId ->

--- a/src/main/asciidoc/ruby/index.adoc
+++ b/src/main/asciidoc/ruby/index.adoc
@@ -170,7 +170,7 @@ endpoint.publish_handler() { |message|
   if (message.qos_level() == :AT_LEAST_ONCE)
     endpoint.publish_acknowledge(message.message_id())
   elsif (message.qos_level() == :EXACTLY_ONCE)
-    endpoint.publish_release(message.message_id())
+    endpoint.publish_received(message.message_id())
   end
 
 }.publish_release_handler() { |messageId|

--- a/src/main/java/examples/VertxMqttServerExamples.java
+++ b/src/main/java/examples/VertxMqttServerExamples.java
@@ -183,7 +183,7 @@ public class VertxMqttServerExamples {
       if (message.qosLevel() == MqttQoS.AT_LEAST_ONCE) {
         endpoint.publishAcknowledge(message.messageId());
       } else if (message.qosLevel() == MqttQoS.EXACTLY_ONCE) {
-        endpoint.publishRelease(message.messageId());
+        endpoint.publishReceived(message.messageId());
       }
 
     }).publishReleaseHandler(messageId -> {


### PR DESCRIPTION
Use 'publishReceived' instead of 'publishRelease' for the Qos of 'EXACTLY_ONCE' case; as mentioned in the docs [(package-info.java)](https://github.com/vert-x3/vertx-mqtt/blob/bedddae60ad982d02bd40cd13a2a0fb643b32dcd/src/main/java/io/vertx/mqtt/package-info.java#L142)