### PR TITLE
fix MqttServer Duplicate handler name: idle

### DIFF
--- a/src/main/java/io/vertx/mqtt/impl/MqttServerImpl.java
+++ b/src/main/java/io/vertx/mqtt/impl/MqttServerImpl.java
@@ -138,7 +138,7 @@ public class MqttServerImpl implements MqttServer {
     }
 
     // adding the idle state handler for timeout on CONNECT packet
-    pipeline.addBefore("handler", "idle", new IdleStateHandler(this.options.timeoutOnConnect(), 0, 0));
+    pipeline.addBefore("handler", "mqttIdle", new IdleStateHandler(this.options.timeoutOnConnect(), 0, 0));
     pipeline.addBefore("handler", "timeoutOnConnect", new ChannelDuplexHandler() {
 
       @Override


### PR DESCRIPTION
When  The NetServerOptions set the ' IdleTimeout'. The connection will add the name 'idle' handler before.
And the mqttserver will add the same name handler too.
