### PR TITLE
Explicit messageId for PUBLISH

### DIFF
--- a/src/main/java/io/vertx/mqtt/MqttEndpoint.java
+++ b/src/main/java/io/vertx/mqtt/MqttEndpoint.java
@@ -377,16 +377,31 @@ public interface MqttEndpoint {
   /**
    * Sends the PUBLISH message to the remote MQTT server
    *
-   * @param topic    topic on which the message is published
-   * @param payload  message payload
-   * @param qosLevel QoS level
-   * @param isDup    if the message is a duplicate
-   * @param isRetain if the message needs to be retained
+   * @param topic              topic on which the message is published
+   * @param payload            message payload
+   * @param qosLevel           QoS level
+   * @param isDup              if the message is a duplicate
+   * @param isRetain           if the message needs to be retained
    * @param publishSentHandler handler called after PUBLISH packet sent with a packetId
    * @return current MQTT client instance
    */
   @Fluent
   MqttEndpoint publish(String topic, Buffer payload, MqttQoS qosLevel, boolean isDup, boolean isRetain, Handler<AsyncResult<Integer>> publishSentHandler);
+
+  /**
+   * Sends the PUBLISH message to the remote MQTT server explicitly specifying the messageId
+   *
+   * @param topic              topic on which the message is published
+   * @param payload            message payload
+   * @param qosLevel           QoS level
+   * @param isDup              if the message is a duplicate
+   * @param isRetain           if the message needs to be retained
+   * @param messageId          message ID
+   * @param publishSentHandler handler called after PUBLISH packet sent with a packetId
+   * @return current MQTT client instance
+   */
+  @Fluent
+  MqttEndpoint publish(String topic, Buffer payload, MqttQoS qosLevel, boolean isDup, boolean isRetain, int messageId, Handler<AsyncResult<Integer>> publishSentHandler);
 
   /**
    * Sends the PINGRESP message to the remote MQTT client


### PR DESCRIPTION
Fix for https://github.com/vert-x3/vertx-mqtt/issues/127. Servers which retain session across the restarts can't rely on built-in `messageId` generation as it's purely in-memory and after the restart, it may generate the same `messageId`s as it generated before and which may not be fully processed yet. For such cases, we need to be able to provide `messageId` from some external source.