### PR TITLE
Fix execution of integration tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -118,9 +118,6 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
-          <excludes>
-            <exclude>**/MqttClient*.java</exclude>
-          </excludes>
           <systemProperties>
             <mqtt.server.host>${mqtt.server.host}</mqtt.server.host>
             <mqtt.server.port>${mqtt.server.port}</mqtt.server.port>
@@ -139,12 +136,6 @@
           </execution>
         </executions>
         <configuration>
-          <includes>
-            <include>**/MqttClient*Test.java</include>
-          </includes>
-          <excludes>
-            <exclude>**/MqttServer*Test.java</exclude>
-          </excludes>
           <systemProperties>
             <mqtt.server.host>${mqtt.server.host}</mqtt.server.host>
             <mqtt.server.port>${mqtt.server.port}</mqtt.server.port>

--- a/src/test/java/io/vertx/mqtt/test/client/MqttClientConnectIT.java
+++ b/src/test/java/io/vertx/mqtt/test/client/MqttClientConnectIT.java
@@ -37,7 +37,7 @@ import static org.junit.Assert.assertTrue;
  * MQTT client testing about connection
  */
 @RunWith(VertxUnitRunner.class)
-public class MqttClientConnectTest {
+public class MqttClientConnectIT {
 
   @Test
   public void connectDisconnect(TestContext context) throws InterruptedException {

--- a/src/test/java/io/vertx/mqtt/test/client/MqttClientIdIT.java
+++ b/src/test/java/io/vertx/mqtt/test/client/MqttClientIdIT.java
@@ -36,9 +36,9 @@ import static org.junit.Assert.*;
  * MQTT client testing on client identifier
  */
 @RunWith(VertxUnitRunner.class)
-public class MqttClientIdTest {
+public class MqttClientIdIT {
 
-  private static final Logger log = LoggerFactory.getLogger(MqttClientIdTest.class);
+  private static final Logger log = LoggerFactory.getLogger(MqttClientIdIT.class);
 
   @Test
   public void afterConnectClientIdGenerated(TestContext context) throws InterruptedException {

--- a/src/test/java/io/vertx/mqtt/test/client/MqttClientMaxMessageSizeIT.java
+++ b/src/test/java/io/vertx/mqtt/test/client/MqttClientMaxMessageSizeIT.java
@@ -36,9 +36,9 @@ import static org.junit.Assert.assertTrue;
  * MQTT client testing about the maximum message size
  */
 @RunWith(VertxUnitRunner.class)
-public class MqttClientMaxMessageSizeTest {
+public class MqttClientMaxMessageSizeIT {
 
-  private static final Logger log = LoggerFactory.getLogger(MqttClientMaxMessageSizeTest.class);
+  private static final Logger log = LoggerFactory.getLogger(MqttClientMaxMessageSizeIT.class);
 
   private static final String MQTT_TOPIC = "/my_topic";
   private static final int MQTT_MAX_MESSAGE_SIZE = 50;

--- a/src/test/java/io/vertx/mqtt/test/client/MqttClientPingIT.java
+++ b/src/test/java/io/vertx/mqtt/test/client/MqttClientPingIT.java
@@ -33,9 +33,9 @@ import static org.junit.Assert.assertTrue;
  * MQTT client testing on keep alive mechanism
  */
 @RunWith(VertxUnitRunner.class)
-public class MqttClientPingTest {
+public class MqttClientPingIT {
 
-  private static final Logger log = LoggerFactory.getLogger(MqttClientPingTest.class);
+  private static final Logger log = LoggerFactory.getLogger(MqttClientPingIT.class);
 
   private static final int PING_NUMBER = 3;
   private static final int KEEPALIVE_TIMEOUT = 2; // seconds

--- a/src/test/java/io/vertx/mqtt/test/client/MqttClientPublishIT.java
+++ b/src/test/java/io/vertx/mqtt/test/client/MqttClientPublishIT.java
@@ -34,9 +34,9 @@ import static org.junit.Assert.assertTrue;
  * MQTT client testing on publishing messages
  */
 @RunWith(VertxUnitRunner.class)
-public class MqttClientPublishTest {
+public class MqttClientPublishIT {
 
-  private static final Logger log = LoggerFactory.getLogger(MqttClientPublishTest.class);
+  private static final Logger log = LoggerFactory.getLogger(MqttClientPublishIT.class);
 
   private static final String MQTT_TOPIC = "/my_topic";
   private static final String MQTT_MESSAGE = "Hello Vert.x MQTT Client";

--- a/src/test/java/io/vertx/mqtt/test/client/MqttClientSubscribeIT.java
+++ b/src/test/java/io/vertx/mqtt/test/client/MqttClientSubscribeIT.java
@@ -36,9 +36,9 @@ import static org.junit.Assert.assertTrue;
  * MQTT client testing on subscribing topics
  */
 @RunWith(VertxUnitRunner.class)
-public class MqttClientSubscribeTest {
+public class MqttClientSubscribeIT {
 
-  private static final Logger log = LoggerFactory.getLogger(MqttClientSubscribeTest.class);
+  private static final Logger log = LoggerFactory.getLogger(MqttClientSubscribeIT.class);
 
   private static final String MQTT_TOPIC = "/my_topic";
   private static final String MQTT_MESSAGE = "Hello Vert.x MQTT Client";

--- a/src/test/java/io/vertx/mqtt/test/client/MqttClientTopicValidationIT.java
+++ b/src/test/java/io/vertx/mqtt/test/client/MqttClientTopicValidationIT.java
@@ -35,9 +35,9 @@ import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertThat;
 
 @RunWith(VertxUnitRunner.class)
-public class MqttClientTopicValidationTest {
+public class MqttClientTopicValidationIT {
 
-  private static final Logger log = LoggerFactory.getLogger(MqttClientTopicValidationTest.class);
+  private static final Logger log = LoggerFactory.getLogger(MqttClientTopicValidationIT.class);
   private static final String MQTT_MESSAGE = "Hello Vert.x MQTT Client";
   private static final int MAX_TOPIC_LEN = 65535;
 

--- a/src/test/java/io/vertx/mqtt/test/client/MqttClientUnsubscribeIT.java
+++ b/src/test/java/io/vertx/mqtt/test/client/MqttClientUnsubscribeIT.java
@@ -33,9 +33,9 @@ import static org.junit.Assert.assertTrue;
  * MQTT client testing on unsubscribing topics
  */
 @RunWith(VertxUnitRunner.class)
-public class MqttClientUnsubscribeTest {
+public class MqttClientUnsubscribeIT {
 
-  private static final Logger log = LoggerFactory.getLogger(MqttClientUnsubscribeTest.class);
+  private static final Logger log = LoggerFactory.getLogger(MqttClientUnsubscribeIT.class);
 
   private static final String MQTT_TOPIC = "/my_topic";
 


### PR DESCRIPTION
Running the integration tests via mvn verify failed because a standard
unit test has been executed as well which caused a bind address
conflict.

The test classes now use the standard naming pattern using *Test for
unit tests and *IT for integration tests. Accordingly, the surefire and
failsafe plugins do not need special include and exclude configuration
anymore.