### PR TITLE
[#164] Prevent leaking of NetClient instances

### DIFF
--- a/src/main/java/io/vertx/mqtt/impl/MqttClientImpl.java
+++ b/src/main/java/io/vertx/mqtt/impl/MqttClientImpl.java
@@ -270,11 +270,13 @@ public class MqttClientImpl implements MqttClient {
 
     io.netty.handler.codec.mqtt.MqttMessage disconnect = MqttMessageFactory.newMessage(fixedHeader, null, null);
 
-    this.write(disconnect);
-
-    connection().close();
-
-    return ctx.succeededFuture();
+    Promise<Void> result = Promise.promise();
+    this.write(disconnect)
+      .onComplete(r -> {
+        this.connection = null;
+        this.client.close(result);
+      });
+    return result.future();
   }
 
   /**


### PR DESCRIPTION
The NetClientImpl used by MqttClientImpl to connect to a server
requires its close() method to be invoked to release some resources
which would otherwise prevent it from being GCed properly.

The MqttClientImpl's disconnect() method has been changed to invoke the
NetClientImpl.close() method instead of just the close() method of the
NetSocketImpl instance that represents the connection to the MQTT
server.