### PR TITLE
Use ephemeral ports for MQTT server tests

### DIFF
--- a/src/test/java/io/vertx/mqtt/test/client/MqttClientOutOfOrderAcksTest.java
+++ b/src/test/java/io/vertx/mqtt/test/client/MqttClientOutOfOrderAcksTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 Red Hat Inc.
+ * Copyright 2017, 2020 Red Hat Inc. and others
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,14 @@
 
 package io.vertx.mqtt.test.client;
 
+import java.util.LinkedList;
+import java.util.Queue;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
 import io.netty.handler.codec.mqtt.MqttQoS;
 import io.vertx.core.Vertx;
 import io.vertx.core.buffer.Buffer;
@@ -25,16 +33,9 @@ import io.vertx.ext.unit.Async;
 import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
 import io.vertx.mqtt.MqttClient;
-import io.vertx.mqtt.MqttClientOptions;
 import io.vertx.mqtt.MqttEndpoint;
 import io.vertx.mqtt.MqttServer;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-
-import java.util.LinkedList;
-import java.util.Queue;
+import io.vertx.mqtt.MqttServerOptions;
 
 
 /**
@@ -46,6 +47,7 @@ public class MqttClientOutOfOrderAcksTest {
 
   private static final String MQTT_TOPIC = "/my_topic";
   private static final String MQTT_MESSAGE = "Hello Vert.x MQTT Client";
+  private static final String MQTT_HOST = "127.0.0.1";
 
   Vertx vertx = Vertx.vertx();
   MqttServer server;
@@ -76,7 +78,7 @@ public class MqttClientOutOfOrderAcksTest {
       async.countDown();
     });
 
-    client.connect(MqttClientOptions.DEFAULT_PORT, MqttClientOptions.DEFAULT_HOST, c -> {
+    client.connect(server.actualPort(), MQTT_HOST, c -> {
 
       // publish QoS = 1 message three times
       for (int i = 0; i < 3; i++)
@@ -93,7 +95,7 @@ public class MqttClientOutOfOrderAcksTest {
 
   @Before
   public void before(TestContext context) {
-    server = MqttServer.create(vertx);
+    server = MqttServer.create(vertx, new MqttServerOptions().setHost(MQTT_HOST).setPort(0));
     server.exceptionHandler(t -> context.fail());
     server.endpointHandler(MqttClientOutOfOrderAcksTest::serverLogic).listen(context.asyncAssertSuccess());
   }

--- a/src/test/java/io/vertx/mqtt/test/server/MqttServerBadClientTest.java
+++ b/src/test/java/io/vertx/mqtt/test/server/MqttServerBadClientTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 Red Hat Inc.
+ * Copyright 2016, 2020 Red Hat Inc. and others
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -97,7 +97,7 @@ public class MqttServerBadClientTest extends MqttServerBaseTest {
         });
 
       // Start the client.
-      ChannelFuture f = bootstrap.connect(MQTT_SERVER_HOST, MQTT_SERVER_PORT).sync();
+      ChannelFuture f = bootstrap.connect(MQTT_SERVER_HOST, serverPort()).sync();
       long tick = System.currentTimeMillis();
 
       MqttClientOptions options = new MqttClientOptions();
@@ -138,7 +138,7 @@ public class MqttServerBadClientTest extends MqttServerBaseTest {
         });
 
       // Start the client.
-      ChannelFuture f = bootstrap.connect(MQTT_SERVER_HOST, MQTT_SERVER_PORT).sync();
+      ChannelFuture f = bootstrap.connect(MQTT_SERVER_HOST, serverPort()).sync();
 
       f.channel().writeAndFlush(createPublishMessage());
 
@@ -159,7 +159,7 @@ public class MqttServerBadClientTest extends MqttServerBaseTest {
     NetClient client = this.vertx.createNetClient();
     Async async = context.async();
 
-    client.connect(MQTT_SERVER_PORT, MQTT_SERVER_HOST, done -> {
+    client.connect(serverPort(), MQTT_SERVER_HOST, done -> {
 
       if (done.succeeded()) {
 

--- a/src/test/java/io/vertx/mqtt/test/server/MqttServerBaseTest.java
+++ b/src/test/java/io/vertx/mqtt/test/server/MqttServerBaseTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 Red Hat Inc.
+ * Copyright 2016, 2020 Red Hat Inc. and others
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,6 +30,7 @@ import org.junit.runner.RunWith;
 import javax.net.ssl.*;
 import java.io.InputStream;
 import java.security.KeyStore;
+import java.util.Optional;
 
 /**
  * Base class for MQTT server unit tests
@@ -39,9 +40,7 @@ public abstract class MqttServerBaseTest {
 
   private static final Logger log = LoggerFactory.getLogger(MqttServerBaseTest.class);
 
-  protected static final String MQTT_SERVER_HOST = "localhost";
-  protected static final int MQTT_SERVER_PORT = 1883;
-  protected static final int MQTT_SERVER_TLS_PORT = 8883;
+  protected static final String MQTT_SERVER_HOST = "127.0.0.1";
 
   protected Vertx vertx;
   protected MqttServer mqttServer;
@@ -57,7 +56,7 @@ public abstract class MqttServerBaseTest {
 
     this.vertx = Vertx.vertx();
     if (options == null) {
-      this.mqttServer = MqttServer.create(this.vertx);
+      this.mqttServer = MqttServer.create(this.vertx, new MqttServerOptions().setHost(MQTT_SERVER_HOST).setPort(0));
     } else {
       this.mqttServer = MqttServer.create(this.vertx, options);
     }
@@ -93,6 +92,10 @@ public abstract class MqttServerBaseTest {
 
     this.mqttServer.close(context.asyncAssertSuccess());
     this.vertx.close(context.asyncAssertSuccess());
+  }
+
+  protected int serverPort() {
+    return Optional.ofNullable(mqttServer).map(MqttServer::actualPort).orElseThrow(IllegalStateException::new);
   }
 
   protected void endpointHandler(MqttEndpoint endpoint, TestContext context) {

--- a/src/test/java/io/vertx/mqtt/test/server/MqttServerClientCertSslTest.java
+++ b/src/test/java/io/vertx/mqtt/test/server/MqttServerClientCertSslTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 Red Hat Inc.
+ * Copyright 2016, 2020 Red Hat Inc. and others
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -61,7 +61,8 @@ public class MqttServerClientCertSslTest extends MqttServerBaseTest {
   @Before
   public void before(TestContext context) {
     MqttServerOptions options = new MqttServerOptions()
-      .setPort(MQTT_SERVER_TLS_PORT)
+      .setHost(MQTT_SERVER_HOST)
+      .setPort(0)
       .setKeyCertOptions(Cert.SERVER_PEM_ROOT_CA.get())
       .setTrustOptions(Trust.SERVER_PEM_ROOT_CA.get())
       .setSsl(true)
@@ -86,7 +87,7 @@ public class MqttServerClientCertSslTest extends MqttServerBaseTest {
     try {
 
       MemoryPersistence persistence = new MemoryPersistence();
-      MqttClient client = new MqttClient(String.format("ssl://%s:%d", MQTT_SERVER_HOST, MQTT_SERVER_TLS_PORT), "12345", persistence);
+      MqttClient client = new MqttClient(String.format("ssl://%s:%d", MQTT_SERVER_HOST, serverPort()), "12345", persistence);
 
       MqttConnectOptions options = new MqttConnectOptions();
       options.setSocketFactory(this.getSocketFactory("/tls/client-truststore-root-ca.jks", "/tls/client-keystore-root-ca.jks"));
@@ -131,7 +132,7 @@ public class MqttServerClientCertSslTest extends MqttServerBaseTest {
     try {
 
       MemoryPersistence persistence = new MemoryPersistence();
-      MqttClient client = new MqttClient(String.format("ssl://%s:%d", MQTT_SERVER_HOST, MQTT_SERVER_TLS_PORT), "12345", persistence);
+      MqttClient client = new MqttClient(String.format("ssl://%s:%d", MQTT_SERVER_HOST, serverPort()), "12345", persistence);
 
       MqttConnectOptions options = new MqttConnectOptions();
       options.setSocketFactory(this.getSocketFactory("/tls/client-truststore-root-ca.jks", "/tls/client-keystore-other-ca.jks"));

--- a/src/test/java/io/vertx/mqtt/test/server/MqttServerClientIdentifierTest.java
+++ b/src/test/java/io/vertx/mqtt/test/server/MqttServerClientIdentifierTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 Red Hat Inc.
+ * Copyright 2016, 2020 Red Hat Inc. and others
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -50,7 +50,7 @@ public class MqttServerClientIdentifierTest extends MqttServerBaseTest {
   public void testInvalidClientIdentifier(TestContext context) throws Exception {
 
     MemoryPersistence persistence = new MemoryPersistence();
-    MqttClient client = new MqttClient(String.format("tcp://%s:%d", MQTT_SERVER_HOST, MQTT_SERVER_PORT), "invalid-id-with-24-chars", persistence);
+    MqttClient client = new MqttClient(String.format("tcp://%s:%d", MQTT_SERVER_HOST, serverPort()), "invalid-id-with-24-chars", persistence);
     MqttConnectOptions options = new MqttConnectOptions();
     options.setMqttVersion(MQTT_VERSION_3_1);
 
@@ -68,7 +68,7 @@ public class MqttServerClientIdentifierTest extends MqttServerBaseTest {
   public void testValidClientIdentifier(TestContext context) throws Exception {
 
     MemoryPersistence persistence = new MemoryPersistence();
-    MqttClient client = new MqttClient(String.format("tcp://%s:%d", MQTT_SERVER_HOST, MQTT_SERVER_PORT), "id-madeof-23-characters", persistence);
+    MqttClient client = new MqttClient(String.format("tcp://%s:%d", MQTT_SERVER_HOST, serverPort()), "id-madeof-23-characters", persistence);
     MqttConnectOptions options = new MqttConnectOptions();
     options.setMqttVersion(MQTT_VERSION_3_1);
 

--- a/src/test/java/io/vertx/mqtt/test/server/MqttServerClientPublishTest.java
+++ b/src/test/java/io/vertx/mqtt/test/server/MqttServerClientPublishTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 Red Hat Inc.
+ * Copyright 2016, 2020 Red Hat Inc. and others
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -81,7 +81,7 @@ public class MqttServerClientPublishTest extends MqttServerBaseTest {
 
     try {
       MemoryPersistence persistence = new MemoryPersistence();
-      MqttClient client = new MqttClient(String.format("tcp://%s:%d", MQTT_SERVER_HOST, MQTT_SERVER_PORT), "12345", persistence);
+      MqttClient client = new MqttClient(String.format("tcp://%s:%d", MQTT_SERVER_HOST, serverPort()), "12345", persistence);
       client.connect();
 
       client.publish(topic, message.getBytes(), qos, false);

--- a/src/test/java/io/vertx/mqtt/test/server/MqttServerConnectionTest.java
+++ b/src/test/java/io/vertx/mqtt/test/server/MqttServerConnectionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 Red Hat Inc.
+ * Copyright 2016, 2020 Red Hat Inc. and others
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -54,6 +54,8 @@ public class MqttServerConnectionTest extends MqttServerBaseTest {
   public void before(TestContext context) {
 
     MqttServerOptions options = new MqttServerOptions();
+    options.setHost(MQTT_SERVER_HOST);
+    options.setPort(0);
     options.setTimeoutOnConnect(MQTT_TIMEOUT_ON_CONNECT);
 
     this.setUp(context, options);
@@ -72,7 +74,7 @@ public class MqttServerConnectionTest extends MqttServerBaseTest {
 
     try {
       MemoryPersistence persistence = new MemoryPersistence();
-      MqttClient client = new MqttClient(String.format("tcp://%s:%d", MQTT_SERVER_HOST, MQTT_SERVER_PORT), "12345", persistence);
+      MqttClient client = new MqttClient(String.format("tcp://%s:%d", MQTT_SERVER_HOST, serverPort()), "12345", persistence);
       client.connect();
     } catch (MqttException e) {
       context.fail(e);
@@ -86,7 +88,7 @@ public class MqttServerConnectionTest extends MqttServerBaseTest {
 
     try {
       MemoryPersistence persistence = new MemoryPersistence();
-      MqttClient client = new MqttClient(String.format("tcp://%s:%d", MQTT_SERVER_HOST, MQTT_SERVER_PORT), "", persistence);
+      MqttClient client = new MqttClient(String.format("tcp://%s:%d", MQTT_SERVER_HOST, serverPort()), "", persistence);
       client.connect();
     } catch (MqttException e) {
       context.fail(e);
@@ -100,7 +102,7 @@ public class MqttServerConnectionTest extends MqttServerBaseTest {
 
     try {
       MemoryPersistence persistence = new MemoryPersistence();
-      MqttClient client = new MqttClient(String.format("tcp://%s:%d", MQTT_SERVER_HOST, MQTT_SERVER_PORT), "12345", persistence);
+      MqttClient client = new MqttClient(String.format("tcp://%s:%d", MQTT_SERVER_HOST, serverPort()), "12345", persistence);
       client.connect();
       context.fail();
     } catch (MqttException e) {
@@ -115,7 +117,7 @@ public class MqttServerConnectionTest extends MqttServerBaseTest {
 
     try {
       MemoryPersistence persistence = new MemoryPersistence();
-      MqttClient client = new MqttClient(String.format("tcp://%s:%d", MQTT_SERVER_HOST, MQTT_SERVER_PORT), "12345", persistence);
+      MqttClient client = new MqttClient(String.format("tcp://%s:%d", MQTT_SERVER_HOST, serverPort()), "12345", persistence);
       client.connect();
       context.fail();
     } catch (MqttException e) {
@@ -133,7 +135,7 @@ public class MqttServerConnectionTest extends MqttServerBaseTest {
       MqttConnectOptions options = new MqttConnectOptions();
       options.setUserName("wrong_username");
       options.setPassword("wrong_password".toCharArray());
-      MqttClient client = new MqttClient(String.format("tcp://%s:%d", MQTT_SERVER_HOST, MQTT_SERVER_PORT), "12345", persistence);
+      MqttClient client = new MqttClient(String.format("tcp://%s:%d", MQTT_SERVER_HOST, serverPort()), "12345", persistence);
       client.connect(options);
       context.fail();
     } catch (MqttException e) {
@@ -148,7 +150,7 @@ public class MqttServerConnectionTest extends MqttServerBaseTest {
 
     try {
       MemoryPersistence persistence = new MemoryPersistence();
-      MqttClient client = new MqttClient(String.format("tcp://%s:%d", MQTT_SERVER_HOST, MQTT_SERVER_PORT), "12345", persistence);
+      MqttClient client = new MqttClient(String.format("tcp://%s:%d", MQTT_SERVER_HOST, serverPort()), "12345", persistence);
       client.connect();
       context.fail();
     } catch (MqttException e) {
@@ -166,7 +168,7 @@ public class MqttServerConnectionTest extends MqttServerBaseTest {
       MqttConnectOptions options = new MqttConnectOptions();
       // trying the old 3.1
       options.setMqttVersion(MqttConnectOptions.MQTT_VERSION_3_1);
-      MqttClient client = new MqttClient(String.format("tcp://%s:%d", MQTT_SERVER_HOST, MQTT_SERVER_PORT), "12345", persistence);
+      MqttClient client = new MqttClient(String.format("tcp://%s:%d", MQTT_SERVER_HOST, serverPort()), "12345", persistence);
       client.connect(options);
       context.fail();
     } catch (MqttException e) {
@@ -180,7 +182,7 @@ public class MqttServerConnectionTest extends MqttServerBaseTest {
     this.expectedReturnCode = MqttConnectReturnCode.CONNECTION_ACCEPTED;
 
     MemoryPersistence persistence = new MemoryPersistence();
-    MqttClient client = new MqttClient(String.format("tcp://%s:%d", MQTT_SERVER_HOST, MQTT_SERVER_PORT), "12345", persistence);
+    MqttClient client = new MqttClient(String.format("tcp://%s:%d", MQTT_SERVER_HOST, serverPort()), "12345", persistence);
     client.connect();
 
     try {
@@ -202,7 +204,7 @@ public class MqttServerConnectionTest extends MqttServerBaseTest {
       MqttConnectOptions options = new MqttConnectOptions();
       options.setCleanSession(false);
       options.setMqttVersion(MqttConnectOptions.MQTT_VERSION_3_1_1);
-      MqttClient client = new MqttClient(String.format("tcp://%s:%d", MQTT_SERVER_HOST, MQTT_SERVER_PORT), "", persistence);
+      MqttClient client = new MqttClient(String.format("tcp://%s:%d", MQTT_SERVER_HOST, serverPort()), "", persistence);
       client.connect(options);
       context.fail();
     } catch (MqttException e) {
@@ -217,7 +219,7 @@ public class MqttServerConnectionTest extends MqttServerBaseTest {
     NetClient client = this.vertx.createNetClient();
     Async async = context.async();
 
-    client.connect(MQTT_SERVER_PORT, MQTT_SERVER_HOST, done -> {
+    client.connect(serverPort(), MQTT_SERVER_HOST, done -> {
 
       if (done.succeeded()) {
 

--- a/src/test/java/io/vertx/mqtt/test/server/MqttServerDisconnectTest.java
+++ b/src/test/java/io/vertx/mqtt/test/server/MqttServerDisconnectTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 Red Hat Inc.
+ * Copyright 2016, 2020 Red Hat Inc. and others
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -54,7 +54,7 @@ public class MqttServerDisconnectTest extends MqttServerBaseTest {
 
     try {
       MemoryPersistence persistence = new MemoryPersistence();
-      MqttClient client = new MqttClient(String.format("tcp://%s:%d", MQTT_SERVER_HOST, MQTT_SERVER_PORT), "12345", persistence);
+      MqttClient client = new MqttClient(String.format("tcp://%s:%d", MQTT_SERVER_HOST, serverPort()), "12345", persistence);
       client.connect();
       client.disconnect();
       context.assertTrue(true);
@@ -69,7 +69,7 @@ public class MqttServerDisconnectTest extends MqttServerBaseTest {
 
     try {
       MemoryPersistence persistence = new MemoryPersistence();
-      MqttClient client = new MqttClient(String.format("tcp://%s:%d", MQTT_SERVER_HOST, MQTT_SERVER_PORT), "12345", persistence);
+      MqttClient client = new MqttClient(String.format("tcp://%s:%d", MQTT_SERVER_HOST, serverPort()), "12345", persistence);
       client.connect();
       client.close();
       context.assertTrue(false);

--- a/src/test/java/io/vertx/mqtt/test/server/MqttServerEndpointStatusTest.java
+++ b/src/test/java/io/vertx/mqtt/test/server/MqttServerEndpointStatusTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 Red Hat Inc.
+ * Copyright 2016, 2020 Red Hat Inc. and others
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -57,7 +57,7 @@ public class MqttServerEndpointStatusTest extends MqttServerBaseTest {
 
     try {
       MemoryPersistence persistence = new MemoryPersistence();
-      MqttClient client = new MqttClient(String.format("tcp://%s:%d", MQTT_SERVER_HOST, MQTT_SERVER_PORT), "12345", persistence);
+      MqttClient client = new MqttClient(String.format("tcp://%s:%d", MQTT_SERVER_HOST, serverPort()), "12345", persistence);
       client.connect();
       context.assertTrue(client.isConnected() && this.endpoint.isConnected());
     } catch (MqttException e) {
@@ -73,7 +73,7 @@ public class MqttServerEndpointStatusTest extends MqttServerBaseTest {
 
     try {
       MemoryPersistence persistence = new MemoryPersistence();
-      MqttClient client = new MqttClient(String.format("tcp://%s:%d", MQTT_SERVER_HOST, MQTT_SERVER_PORT), "12345", persistence);
+      MqttClient client = new MqttClient(String.format("tcp://%s:%d", MQTT_SERVER_HOST, serverPort()), "12345", persistence);
       client.connect();
       client.disconnect();
 
@@ -99,7 +99,7 @@ public class MqttServerEndpointStatusTest extends MqttServerBaseTest {
 
     try {
       MemoryPersistence persistence = new MemoryPersistence();
-      MqttClient client = new MqttClient(String.format("tcp://%s:%d", MQTT_SERVER_HOST, MQTT_SERVER_PORT), "12345", persistence);
+      MqttClient client = new MqttClient(String.format("tcp://%s:%d", MQTT_SERVER_HOST, serverPort()), "12345", persistence);
       client.connect();
 
       // the local endpoint closes connection after a few seconds

--- a/src/test/java/io/vertx/mqtt/test/server/MqttServerMaxMessageSizeTest.java
+++ b/src/test/java/io/vertx/mqtt/test/server/MqttServerMaxMessageSizeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 Red Hat Inc.
+ * Copyright 2016, 2020 Red Hat Inc. and others
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -50,6 +50,8 @@ public class MqttServerMaxMessageSizeTest extends MqttServerBaseTest {
   public void before(TestContext context) {
 
     MqttServerOptions options = new MqttServerOptions();
+    options.setHost(MQTT_SERVER_HOST);
+    options.setPort(0);
     options.setMaxMessageSize(MQTT_MAX_MESSAGE_SIZE);
 
     this.setUp(context, options);
@@ -63,7 +65,7 @@ public class MqttServerMaxMessageSizeTest extends MqttServerBaseTest {
     try {
 
       MemoryPersistence persistence = new MemoryPersistence();
-      MqttClient client = new MqttClient(String.format("tcp://%s:%d", MQTT_SERVER_HOST, MQTT_SERVER_PORT), "12345", persistence);
+      MqttClient client = new MqttClient(String.format("tcp://%s:%d", MQTT_SERVER_HOST, serverPort()), "12345", persistence);
       client.connect();
 
       byte[] message = new byte[MQTT_BIG_MESSAGE_SIZE];

--- a/src/test/java/io/vertx/mqtt/test/server/MqttServerNetworkIssueTest.java
+++ b/src/test/java/io/vertx/mqtt/test/server/MqttServerNetworkIssueTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 Red Hat Inc.
+ * Copyright 2016, 2020 Red Hat Inc. and others
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -52,7 +52,7 @@ public class MqttServerNetworkIssueTest extends MqttServerBaseTest {
 
     this.setUp(context);
 
-    this.proxy = new Proxy(this.vertx, MQTT_SERVER_HOST, MQTT_SERVER_PORT);
+    this.proxy = new Proxy(this.vertx, MQTT_SERVER_HOST, serverPort());
     this.proxy.start(context.asyncAssertSuccess());
   }
 

--- a/src/test/java/io/vertx/mqtt/test/server/MqttServerSslTest.java
+++ b/src/test/java/io/vertx/mqtt/test/server/MqttServerSslTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 Red Hat Inc.
+ * Copyright 2016, 2020 Red Hat Inc. and others
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -52,7 +52,8 @@ public class MqttServerSslTest extends MqttServerBaseTest {
   public void before(TestContext context) {
 
     MqttServerOptions options = new MqttServerOptions()
-      .setPort(MQTT_SERVER_TLS_PORT)
+      .setHost(MQTT_SERVER_HOST)
+      .setPort(0)
       .setKeyCertOptions(Cert.SERVER_PEM_ROOT_CA.get())
       .setSsl(true);
 
@@ -70,7 +71,7 @@ public class MqttServerSslTest extends MqttServerBaseTest {
     try {
 
       MemoryPersistence persistence = new MemoryPersistence();
-      MqttClient client = new MqttClient(String.format("ssl://%s:%d", MQTT_SERVER_HOST, MQTT_SERVER_TLS_PORT), "12345", persistence);
+      MqttClient client = new MqttClient(String.format("ssl://%s:%d", MQTT_SERVER_HOST, serverPort()), "12345", persistence);
 
       MqttConnectOptions options = new MqttConnectOptions();
       options.setSocketFactory(this.getSocketFactory("/tls/client-truststore-root-ca.jks", null));

--- a/src/test/java/io/vertx/mqtt/test/server/MqttServerSubscribeTest.java
+++ b/src/test/java/io/vertx/mqtt/test/server/MqttServerSubscribeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 Red Hat Inc.
+ * Copyright 2016, 2020 Red Hat Inc. and others
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -91,7 +91,7 @@ public class MqttServerSubscribeTest extends MqttServerBaseTest {
 
     try {
       MemoryPersistence persistence = new MemoryPersistence();
-      MqttClient client = new MqttClient(String.format("tcp://%s:%d", MQTT_SERVER_HOST, MQTT_SERVER_PORT), "12345", persistence);
+      MqttClient client = new MqttClient(String.format("tcp://%s:%d", MQTT_SERVER_HOST, serverPort()), "12345", persistence);
       client.connect();
 
       String[] topics = new String[]{topic};
@@ -116,7 +116,7 @@ public class MqttServerSubscribeTest extends MqttServerBaseTest {
     Async async = context.async();
 
     NetClient client = vertx.createNetClient();
-    client.connect(MQTT_SERVER_PORT, MQTT_SERVER_HOST, context.asyncAssertSuccess(so -> {
+    client.connect(serverPort(), MQTT_SERVER_HOST, context.asyncAssertSuccess(so -> {
       so.write(Buffer.buffer(new byte[]{
         0x10,                         // HEADER
         0x11,                         // MSG LEN

--- a/src/test/java/io/vertx/mqtt/test/server/MqttServerUnsubscribeTest.java
+++ b/src/test/java/io/vertx/mqtt/test/server/MqttServerUnsubscribeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 Red Hat Inc.
+ * Copyright 2016, 2020 Red Hat Inc. and others
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -67,7 +67,7 @@ public class MqttServerUnsubscribeTest extends MqttServerBaseTest {
 
     try {
       MemoryPersistence persistence = new MemoryPersistence();
-      MqttClient client = new MqttClient(String.format("tcp://%s:%d", MQTT_SERVER_HOST, MQTT_SERVER_PORT), "12345", persistence);
+      MqttClient client = new MqttClient(String.format("tcp://%s:%d", MQTT_SERVER_HOST, serverPort()), "12345", persistence);
       client.connect();
 
       String[] topics = new String[]{MQTT_TOPIC};


### PR DESCRIPTION
This allows for running multiple test classes in parallel.
