### PR TITLE
Prepare for MQTT5 changes

### DIFF
--- a/src/main/java/io/vertx/mqtt/impl/MqttClientImpl.java
+++ b/src/main/java/io/vertx/mqtt/impl/MqttClientImpl.java
@@ -568,7 +568,7 @@ public class MqttClientImpl implements MqttClient {
       false,
       0);
 
-    MqttMessageIdAndPropertiesVariableHeader variableHeader = new MqttMessageIdAndPropertiesVariableHeader(nextMessageId(), new MqttProperties());
+    MqttMessageIdVariableHeader variableHeader = new MqttMessageIdAndPropertiesVariableHeader(nextMessageId(), MqttProperties.NO_PROPERTIES);
     List<MqttTopicSubscription> subscriptions = topics.entrySet()
       .stream()
       .map(e -> new MqttTopicSubscription(e.getKey(), valueOf(e.getValue())))
@@ -635,7 +635,7 @@ public class MqttClientImpl implements MqttClient {
       false,
       0);
 
-    MqttMessageIdAndPropertiesVariableHeader variableHeader = new MqttMessageIdAndPropertiesVariableHeader(nextMessageId(), new MqttProperties());
+    MqttMessageIdVariableHeader variableHeader = new MqttMessageIdAndPropertiesVariableHeader(nextMessageId(), MqttProperties.NO_PROPERTIES);
 
     MqttUnsubscribePayload payload = new MqttUnsubscribePayload(Stream.of(topic).collect(Collectors.toList()));
 

--- a/src/main/java/io/vertx/mqtt/impl/MqttEndpointImpl.java
+++ b/src/main/java/io/vertx/mqtt/impl/MqttEndpointImpl.java
@@ -367,8 +367,9 @@ public class MqttEndpointImpl implements MqttEndpoint {
       new MqttFixedHeader(MqttMessageType.UNSUBACK, false, MqttQoS.AT_MOST_ONCE, false, 0);
     MqttMessageIdVariableHeader variableHeader =
       MqttMessageIdVariableHeader.from(unsubscribeMessageId);
+    MqttUnsubAckPayload payload = new MqttUnsubAckPayload();
 
-    io.netty.handler.codec.mqtt.MqttMessage unsuback = MqttMessageFactory.newMessage(fixedHeader, variableHeader, new MqttUnsubAckPayload());
+    io.netty.handler.codec.mqtt.MqttMessage unsuback = MqttMessageFactory.newMessage(fixedHeader, variableHeader, payload);
 
     this.write(unsuback);
 

--- a/src/test/java/io/vertx/mqtt/test/server/MqttServerSubscribeTest.java
+++ b/src/test/java/io/vertx/mqtt/test/server/MqttServerSubscribeTest.java
@@ -111,7 +111,7 @@ public class MqttServerSubscribeTest extends MqttServerBaseTest {
   }
 
   @Test
-  public void subscribeUnsupportedQos(TestContext context) {
+  public void subscribeUnsupportedMqttVersion(TestContext context) {
 
     Async async = context.async();
 
@@ -122,8 +122,8 @@ public class MqttServerSubscribeTest extends MqttServerBaseTest {
         0x11,                         // MSG LEN
         0x00, 0x04,                   // PROTOCOL NAME LENGTH
         0x4D, 0x51, 0x54, 0x54,       // MQTT
-        0x03,                         // LEVEL
-        0x02,                         // FLAGS
+        0x06,                         // VERSION
+        0x02,                         // QOS
         0x00, 0x3C,                   // KEEP ALIVE
         0x00, 0x05,                   // CLIENT ID LENGTH
         0x31, 0x32, 0x33, 0x34, 0x35, // CLIENT ID (12345)


### PR DESCRIPTION
Adapt for Netty `4.1.52.Final` in order to unlock the work on MQTT5 (https://github.com/vert-x3/vertx-mqtt/issues/161).
Depends on https://github.com/vert-x3/vertx-dependencies/pull/49. 
