### PR TITLE
Rewrite the client ping disconnection on a missing response.

### DIFF
--- a/src/main/java/io/vertx/mqtt/MqttClientOptions.java
+++ b/src/main/java/io/vertx/mqtt/MqttClientOptions.java
@@ -293,6 +293,9 @@ public class MqttClientOptions extends NetClientOptions {
    * @return current options instance
    */
   public MqttClientOptions setKeepAliveInterval(int keepAliveInterval) {
+    if (keepAliveInterval < 1) {
+      throw new IllegalArgumentException("Invalid keep alive interval " + keepAliveInterval);
+    }
     this.keepAliveInterval = keepAliveInterval;
     return this;
   }

--- a/src/main/java/io/vertx/mqtt/impl/MqttClientImpl.java
+++ b/src/main/java/io/vertx/mqtt/impl/MqttClientImpl.java
@@ -18,7 +18,6 @@ package io.vertx.mqtt.impl;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
-import io.netty.channel.ChannelDuplexHandler;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelPipeline;
 import io.netty.handler.codec.DecoderResult;
@@ -62,12 +61,13 @@ import io.vertx.mqtt.messages.MqttSubAckMessage;
 
 import java.io.UnsupportedEncodingException;
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayDeque;
 import java.util.Collections;
+import java.util.Deque;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
-import java.util.concurrent.TimeUnit;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -135,6 +135,10 @@ public class MqttClientImpl implements MqttClient {
   // counter for the message identifier
   private int messageIdCounter;
 
+  // Keep alive management
+  private final long keepAliveTimeout;
+  private Deque<Ping> pings = new ArrayDeque<>();
+
   // total number of unacknowledged packets
   private int countInflightQueue;
 
@@ -155,6 +159,7 @@ public class MqttClientImpl implements MqttClient {
 
     this.vertx = (VertxInternal) vertx;
     this.options = new MqttClientOptions(options);
+    this.keepAliveTimeout = ((options.getKeepAliveInterval() * 1000) * 3) / 2;
   }
 
   int getInFlightMessagesCount() {
@@ -678,19 +683,41 @@ public class MqttClientImpl implements MqttClient {
     return this.closeHandler;
   }
 
+  private class Ping {
+    final long id;
+    private Ping(long id) {
+      this.id = id;
+    }
+    void ack() {
+      vertx.cancelTimer(id);
+    }
+    void cancel() {
+      vertx.cancelTimer(id);
+    }
+  }
+
   /**
    * See {@link MqttClient#ping()} for more details
    */
   @Override
   public MqttClient ping() {
+    if (Vertx.currentContext() == ctx) {
 
-    MqttFixedHeader fixedHeader =
-      new MqttFixedHeader(MqttMessageType.PINGREQ, false, MqttQoS.AT_MOST_ONCE, false, 0);
+      MqttFixedHeader fixedHeader =
+        new MqttFixedHeader(MqttMessageType.PINGREQ, false, MqttQoS.AT_MOST_ONCE, false, 0);
 
-    io.netty.handler.codec.mqtt.MqttMessage pingreq = MqttMessageFactory.newMessage(fixedHeader, null, null);
+      io.netty.handler.codec.mqtt.MqttMessage pingreq = MqttMessageFactory.newMessage(fixedHeader, null, null);
 
-    this.write(pingreq);
+      long id = vertx.setTimer(keepAliveTimeout, _id -> {
+        disconnect();
+      });
 
+      pings.add(new Ping(id));
+
+      this.write(pingreq);
+    } else {
+      ctx.runOnContext(v -> ping());
+    }
     return this;
   }
 
@@ -812,18 +839,6 @@ public class MqttClientImpl implements MqttClient {
             }
           }
         });
-
-
-      long keepAliveTimeout = (keepAliveInterval * 1000) * 3 / 2;
-      // handler for ping-response timeout. connection will be closed if broker READER_IDLE extends timeout
-      pipeline.addBefore("handler", "idleTimeout", new IdleStateHandler(keepAliveTimeout, 0L, 0L, TimeUnit.MILLISECONDS) {
-        @Override
-        protected void channelIdle(ChannelHandlerContext ctx, IdleStateEvent evt) {
-          if (evt.state() == IdleState.READER_IDLE) {
-            ctx.close();
-          }
-        }
-      });
     }
   }
 
@@ -855,16 +870,24 @@ public class MqttClientImpl implements MqttClient {
     Promise<MqttConnAckMessage> connectPromise;
     Promise<Void> disconnectPromise;
     NetClient client;
+    Deque<Ping> pings;
     synchronized (this) {
       client = this.client;
       connectPromise = this.connectPromise;
       disconnectPromise = this.disconnectPromise;
+      pings = this.pings;
       this.disconnectPromise = null;
       this.status = Status.CLOSED;
       this.connection = null;
       this.ctx = null;
       this.client = null;
+      this.pings = new ArrayDeque<>();
     }
+
+    // Cleanup pending pings
+    pings.forEach(ping -> {
+      ping.cancel();
+    });
 
     Handler<Void> handler = closeHandler();
     if (handler != null) {
@@ -978,6 +1001,11 @@ public class MqttClientImpl implements MqttClient {
    * Used for calling the pingresp handler when the server replies to the ping
    */
   private void handlePingresp() {
+
+    Ping ping = pings.poll();
+    if (ping != null) {
+      ping.ack();
+    }
 
     Handler<Void> handler = pingResponseHandler();
     if (handler != null) {

--- a/src/main/java/io/vertx/mqtt/impl/MqttServerConnection.java
+++ b/src/main/java/io/vertx/mqtt/impl/MqttServerConnection.java
@@ -251,7 +251,8 @@ public class MqttServerConnection {
     if (msg.variableHeader().keepAliveTimeSeconds() != 0) {
 
       // the server waits for one and a half times the keep alive time period (MQTT spec)
-      int keepAliveTimeout = (int)(msg.variableHeader().keepAliveTimeSeconds() * 1.5);
+      // round to upper value to account for small keep-alive value (for testing)
+      int keepAliveTimeout = (int)Math.ceil(msg.variableHeader().keepAliveTimeSeconds() * 1.5D);
 
       // modifying the channel pipeline for adding the idle state handler with previous timeout
       chctx.pipeline().addBefore("handler", "idle", new IdleStateHandler(keepAliveTimeout, 0, 0));

--- a/src/test/java/io/vertx/mqtt/test/server/MqttServerNetworkIssueTest.java
+++ b/src/test/java/io/vertx/mqtt/test/server/MqttServerNetworkIssueTest.java
@@ -67,7 +67,7 @@ public class MqttServerNetworkIssueTest extends MqttServerBaseTest {
   public void keepAliveTimeout(TestContext context) {
 
     Async async = context.async();
-    int keepAliveInterval = 5;
+    int keepAliveInterval = 6;
     // MQTT spec : server will wait half more then the keepAliveInterval
     int timeout = keepAliveInterval + keepAliveInterval / 2;
 
@@ -112,7 +112,8 @@ public class MqttServerNetworkIssueTest extends MqttServerBaseTest {
 
       long elapsed = ended - started;
       // consider a range of 500 ms
-      context.assertTrue(elapsed > (timeout * 1000 - 500) && elapsed < (timeout * 1000 + 500));
+      context.assertTrue(elapsed > (timeout * 1000 - 500) && elapsed < (timeout * 1000 + 500),
+        elapsed + " > " + ((timeout * 1000 - 500)) + " && " + elapsed + " < " + (timeout * 1000 + 500) + " != true");
 
     } catch (MqttException e) {
       context.fail(e);


### PR DESCRIPTION
The implementation relies on an IdleStateHandler to close the connection when the server has not sent any response. This does not work when the client manually sends a ping request.

We need to change that, so that any call to the ping method will schedule a timer to disconnect the client and cancel this timer when the ping response is received.

close #183
close #184
close #185

