### PR TITLE
Fix an infinite recursion that can only end in a StackOverflowException

### DIFF
--- a/src/main/java/io/vertx/mqtt/impl/MqttClientImpl.java
+++ b/src/main/java/io/vertx/mqtt/impl/MqttClientImpl.java
@@ -192,7 +192,7 @@ public class MqttClientImpl implements MqttClient {
   @Override
   public Future<MqttConnAckMessage> connect(int port, String host, String serverName) {
 
-    return connect(port, host, serverName);
+    return this.doConnect(port, host, serverName);
   }
 
   /**


### PR DESCRIPTION
Motivation:

Fix a StackOverflowException.

Conformance:

Your commits should be signed and you should have signed the Eclipse Contributor Agreement as explained in https://github.com/eclipse/vert.x/blob/master/CONTRIBUTING.md
Please also make sure you adhere to the code style guidelines: https://github.com/vert-x3/wiki/wiki/Vert.x-code-style-guidelines
