### PR TITLE
Add websocket compression with "sec-websocket-Extensions: permessage-deflate"

### DIFF
--- a/src/main/java/io/vertx/mqtt/MqttServerOptions.java
+++ b/src/main/java/io/vertx/mqtt/MqttServerOptions.java
@@ -42,6 +42,11 @@ public class MqttServerOptions extends NetServerOptions {
   public static final int DEFAULT_MAX_MESSAGE_SIZE = -1;
   public static final int DEFAULT_TIMEOUT_ON_CONNECT = 90;
   public static final int DEFAULT_WEB_SOCKET_MAX_FRAME_SIZE = 65536;
+  public static final boolean DEFAULT_PER_FRAME_WEBSOCKET_COMPRESSION_SUPPORTED = true;
+  public static final boolean DEFAULT_PER_MESSAGE_WEBSOCKET_COMPRESSION_SUPPORTED = true;
+  public static final int DEFAULT_WEBSOCKET_COMPRESSION_LEVEL = 6;
+  public static final boolean DEFAULT_WEBSOCKET_ALLOW_SERVER_NO_CONTEXT = false;
+  public static final boolean DEFAULT_WEBSOCKET_PREFERRED_CLIENT_NO_CONTEXT = false;
 
 
   public static final String MQTT_SUBPROTOCOL_CSV_LIST = "mqtt, mqttv3.1, mqttv3.1.1";
@@ -57,6 +62,12 @@ public class MqttServerOptions extends NetServerOptions {
   // max WebSocket frame size
   private int webSocketMaxFrameSize;
 
+  private boolean perFrameWebSocketCompressionSupported;
+  private boolean perMessageWebSocketCompressionSupported;
+  private int webSocketCompressionLevel;
+  private boolean webSocketAllowServerNoContext;
+  private boolean webSocketPreferredClientNoContext;
+
   /**
    * Default constructor
    */
@@ -68,6 +79,12 @@ public class MqttServerOptions extends NetServerOptions {
     this.isAutoClientId = true;
     this.timeoutOnConnect = DEFAULT_TIMEOUT_ON_CONNECT;
     this.webSocketMaxFrameSize = DEFAULT_WEB_SOCKET_MAX_FRAME_SIZE;
+
+    this.perFrameWebSocketCompressionSupported = DEFAULT_PER_FRAME_WEBSOCKET_COMPRESSION_SUPPORTED;
+    this.perMessageWebSocketCompressionSupported = DEFAULT_PER_MESSAGE_WEBSOCKET_COMPRESSION_SUPPORTED;
+    this.webSocketCompressionLevel = DEFAULT_WEBSOCKET_COMPRESSION_LEVEL;
+    this.webSocketAllowServerNoContext = DEFAULT_WEBSOCKET_ALLOW_SERVER_NO_CONTEXT;
+    this.webSocketPreferredClientNoContext = DEFAULT_WEBSOCKET_PREFERRED_CLIENT_NO_CONTEXT;
   }
 
   /**
@@ -339,5 +356,104 @@ public class MqttServerOptions extends NetServerOptions {
   public void setWebSocketMaxFrameSize(int webSocketMaxFrameSize) {
     Arguments.require(webSocketMaxFrameSize > 0, "WebSocket max frame size must be > 0");
     this.webSocketMaxFrameSize = webSocketMaxFrameSize;
+  }
+
+  /**
+   * Get whether WebSocket the per-frame deflate compression extension is supported.
+   *
+   * @return {@code true} if the http server will accept the per-frame deflate compression extension
+   */
+  public boolean isPerFrameWebSocketCompressionSupported() {
+    return perFrameWebSocketCompressionSupported;
+  }
+
+  /**
+   * Enable or disable support for the WebSocket per-frame deflate compression extension.
+   *
+   * @param supported {@code true} when the per-frame deflate compression extension is supported
+   * @return a reference to this, so the API can be used fluently
+   */
+  public MqttServerOptions setPerFrameWebSocketCompressionSupported(boolean supported) {
+    this.perFrameWebSocketCompressionSupported = supported;
+    return this;
+  }
+
+
+  /**
+   * Get whether WebSocket the per-frame deflate compression extension is supported.
+   *
+   * @return {@code true} if the http server will accept the per-frame deflate compression extension
+   */
+  public boolean isPerMessageWebSocketCompressionSupported() {
+    return perMessageWebSocketCompressionSupported;
+  }
+
+  /**
+   * Enable or disable support for WebSocket per-message deflate compression extension.
+   *
+   * @param supported {@code true} when the per-message WebSocket compression extension is supported
+   * @return a reference to this, so the API can be used fluently
+   */
+  public MqttServerOptions setPerMessageWebSocketCompressionSupported(boolean supported) {
+    this.perMessageWebSocketCompressionSupported = supported;
+    return this;
+  }
+
+  /**
+   * @return the current WebSocket deflate compression level
+   */
+  public int getWebSocketCompressionLevel() {
+    return webSocketCompressionLevel;
+  }
+
+  /**
+   * Set the WebSocket compression level.
+   *
+   * @param compressionLevel the compression level
+   * @return a reference to this, so the API can be used fluently
+   */
+  public MqttServerOptions setWebSocketCompressionLevel(int compressionLevel) {
+    this.webSocketCompressionLevel = compressionLevel;
+    return this;
+  }
+
+  /**
+   * @return {@code true} when the WebSocket server will accept the {@code server_no_context_takeover} parameter for the per-message
+   * deflate compression extension offered by the client
+   */
+  public boolean isWebSocketAllowServerNoContext() {
+    return webSocketAllowServerNoContext;
+  }
+
+  /**
+   * Set whether the WebSocket server will accept the {@code server_no_context_takeover} parameter of the per-message
+   * deflate compression extension offered by the client.
+   *
+   * @param accept {@code true} to accept the {@literal server_no_context_takeover} parameter when the client offers it
+   * @return a reference to this, so the API can be used fluently
+   */
+  public MqttServerOptions setWebSocketAllowServerNoContext(boolean accept) {
+    this.webSocketAllowServerNoContext = accept;
+    return this;
+  }
+
+  /**
+   * @return {@code true} when the WebSocket server will accept the {@code client_no_context_takeover} parameter for the per-message
+   * deflate compression extension offered by the client
+   */
+  public boolean isWebSocketPreferredClientNoContext() {
+    return webSocketPreferredClientNoContext;
+  }
+
+  /**
+   * Set whether the WebSocket server will accept the {@code client_no_context_takeover} parameter of the per-message
+   * deflate compression extension offered by the client.
+   *
+   * @param accept {@code true} to accept the {@code client_no_context_takeover} parameter when the client offers it
+   * @return a reference to this, so the API can be used fluently
+   */
+  public MqttServerOptions setWebSocketPreferredClientNoContext(boolean accept) {
+    this.webSocketPreferredClientNoContext = accept;
+    return this;
   }
 }

--- a/src/test/java/io/vertx/mqtt/test/server/MqttServerWebSocketPermessageDeflateTest.java
+++ b/src/test/java/io/vertx/mqtt/test/server/MqttServerWebSocketPermessageDeflateTest.java
@@ -1,0 +1,69 @@
+package io.vertx.mqtt.test.server;
+
+import io.vertx.core.MultiMap;
+import io.vertx.core.Vertx;
+import io.vertx.core.http.WebSocket;
+import io.vertx.core.http.WebSocketConnectOptions;
+import io.vertx.ext.unit.Async;
+import io.vertx.ext.unit.TestContext;
+import io.vertx.ext.unit.junit.VertxUnitRunner;
+import io.vertx.mqtt.MqttEndpoint;
+import io.vertx.mqtt.MqttServer;
+import io.vertx.mqtt.MqttServerOptions;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+
+@RunWith(VertxUnitRunner.class)
+public class MqttServerWebSocketPermessageDeflateTest {
+
+  protected static final String MQTT_SERVER_HOST = "localhost";
+  protected static final int MQTT_SERVER_PORT = 1883;
+
+  private Vertx vertx;
+
+  @Before
+  public void before() {
+    this.vertx = Vertx.vertx();
+  }
+
+  @After
+  public void after(TestContext context) {
+    this.vertx.close(context.asyncAssertSuccess());
+  }
+
+  @Test
+  public void testPermessageDeflate(TestContext context) {
+    MqttServerOptions options = new MqttServerOptions()
+      .setHost(MQTT_SERVER_HOST)
+      .setPort(MQTT_SERVER_PORT)
+      .setUseWebSocket(true);
+    MqttServer server = MqttServer.create(vertx, options);
+    Async done = context.async();
+    server.endpointHandler(MqttEndpoint::accept);
+    Async listen = context.async();
+    server.listen(context.asyncAssertSuccess(s -> listen.complete()));
+    listen.awaitSuccess(15_000);
+
+    vertx.createHttpClient()
+      .webSocket(new WebSocketConnectOptions()
+        .setPort(MQTT_SERVER_PORT)
+        .setHost(MQTT_SERVER_HOST)
+        .setURI("/mqtt")
+        .setHeaders(MultiMap.caseInsensitiveMultiMap().add("sec-websocket-extensions", "permessage-deflate"))
+      )
+      .onComplete(handler -> {
+        if (handler.succeeded()) {
+          WebSocket webSocket = handler.result();
+          MultiMap handshakeHeaders = webSocket.headers();
+
+          context.assertEquals("permessage-deflate", handshakeHeaders.get("sec-websocket-extensions"));
+          done.complete();
+        } else {
+          context.fail();
+        }
+      });
+  }
+}


### PR DESCRIPTION
This pull request adds support for `permessage-deflate` compression to the mqtt-server if connected via a websocket.

The implementation and configuration is an adjusted version of the implementation in vert.x-core, see [here](https://github.com/eclipse-vertx/vert.x/blob/master/src/main/java/io/vertx/core/http/impl/HttpServerConnectionHandler.java#L87) and [here](https://github.com/eclipse-vertx/vert.x/blob/master/src/main/java/io/vertx/core/http/HttpServerOptions.java#L120).
