### PR TITLE
Make default max message size the same as Netty.

### DIFF
--- a/src/main/java/io/vertx/mqtt/MqttServerOptions.java
+++ b/src/main/java/io/vertx/mqtt/MqttServerOptions.java
@@ -39,7 +39,7 @@ public class MqttServerOptions extends NetServerOptions {
   public static final int DEFAULT_PORT = 1883; // Default port is 1883 for MQTT
   public static final int DEFAULT_TLS_PORT = 8883; // Default TLS port is 8883 for MQTT
 
-  public static final int DEFAULT_MAX_MESSAGE_SIZE = -1;
+  public static final int DEFAULT_MAX_MESSAGE_SIZE = 8092;
   public static final int DEFAULT_TIMEOUT_ON_CONNECT = 90;
   public static final int DEFAULT_WEB_SOCKET_MAX_FRAME_SIZE = 65536;
 
@@ -218,8 +218,8 @@ public class MqttServerOptions extends NetServerOptions {
    * @return  MQTT server options instance
    */
   public MqttServerOptions setMaxMessageSize(int maxMessageSize) {
-    Arguments.require(maxMessageSize > 0 || maxMessageSize == DEFAULT_MAX_MESSAGE_SIZE, "maxMessageSize must be > 0");
-    if ((maxMessageSize > 0) && (this.getReceiveBufferSize() > 0)) {
+    Arguments.require(maxMessageSize > 0, "maxMessageSize must be > 0");
+    if (this.getReceiveBufferSize() > 0) {
       Arguments.require(this.getReceiveBufferSize() >= maxMessageSize,
         "Receiver buffer size can't be lower than max message size");
     }

--- a/src/main/java/io/vertx/mqtt/impl/MqttServerImpl.java
+++ b/src/main/java/io/vertx/mqtt/impl/MqttServerImpl.java
@@ -185,13 +185,7 @@ public class MqttServerImpl implements MqttServer {
   private void initChannel(ChannelPipeline pipeline) {
 
     pipeline.addBefore("handler", "mqttEncoder", MqttEncoder.INSTANCE);
-    if (this.options.getMaxMessageSize() > 0) {
-      pipeline.addBefore("handler", "mqttDecoder", new MqttDecoder(this.options.getMaxMessageSize()));
-    } else {
-      // max message size not set, so the default from Netty MQTT codec is used
-      pipeline.addBefore("handler", "mqttDecoder", new MqttDecoder());
-    }
-
+    pipeline.addBefore("handler", "mqttDecoder", new MqttDecoder(this.options.getMaxMessageSize()));
     // adding the idle state handler for timeout on CONNECT packet
     pipeline.addBefore("handler", "idle", new IdleStateHandler(this.options.timeoutOnConnect(), 0, 0));
     pipeline.addBefore("handler", "timeoutOnConnect", new ChannelDuplexHandler() {


### PR DESCRIPTION
## Motivation:

Make the default max message size the same as Netty `8092`, it can also help to support `maxClientIdLength` easily.

Snapshot:

<img width="717" alt="image" src="https://user-images.githubusercontent.com/74767115/202625966-04000548-5a1c-49ea-bbf9-8be70db83a3c.png">

