### PR TITLE
MqttClientOptions setTimeout should only set the keep alive interval for valid values (greater than 0)

### DIFF
--- a/src/main/java/io/vertx/mqtt/MqttClientOptions.java
+++ b/src/main/java/io/vertx/mqtt/MqttClientOptions.java
@@ -461,7 +461,17 @@ public class MqttClientOptions extends NetClientOptions {
   @Deprecated
   @Override
   public MqttClientOptions setIdleTimeout(int idleTimeout) {
-    return setKeepAliveInterval(idleTimeout);
+    if (idleTimeout > 0) {
+      return setKeepAliveInterval(idleTimeout);
+    } else {
+      return this;
+    }
+  }
+
+  @Override
+  public int getIdleTimeout() {
+    // Disabled
+    return 0;
   }
 
   @Override


### PR DESCRIPTION
The deprecated use of idle timeout in MqttClientOptions sets the keep alive interval, the idle timeout getter should return the keep alive interval for consistency purpose.
