### PR TITLE
MQTT client TLS connection must set the hostname verification algorithm

### DIFF
--- a/src/main/asciidoc/index.adoc
+++ b/src/main/asciidoc/index.adoc
@@ -346,6 +346,21 @@ WARNING: The handler WILL NOT BE CALLED if sent publish packet with QoS=0.
 {@link examples.VertxMqttClientExamples#example9}
 ----
 
+== Connecting using TLS
+
+You can connect to an MQTT server using TLS by configuring the client TCP options, make sure to set:
+
+- the ssl flag
+- the server certificate or the trust all flag
+- the hostname verification algorithm to `"HTTPS"` if you want to verify the server identity otherwise `""`
+
+[source,$lang]
+----
+{@link examples.VertxMqttClientExamples#tls}
+----
+
+NOTE: more details on the TLS client config can be found https://vertx.io/docs/vertx-core/java/#_enabling_ssltls_on_the_client[here]
+
 === Use proxy protocol
 
 [source,$lang]

--- a/src/main/java/examples/VertxMqttClientExamples.java
+++ b/src/main/java/examples/VertxMqttClientExamples.java
@@ -20,6 +20,8 @@ import io.netty.handler.codec.mqtt.MqttQoS;
 import io.vertx.core.Handler;
 import io.vertx.core.Vertx;
 import io.vertx.core.buffer.Buffer;
+import io.vertx.core.net.NetClientOptions;
+import io.vertx.core.net.PemTrustOptions;
 import io.vertx.mqtt.MqttClient;
 import io.vertx.mqtt.MqttClientOptions;
 
@@ -148,6 +150,19 @@ public class VertxMqttClientExamples {
     client.pingResponseHandler(s -> {
       //The handler will be called time to time by default
       System.out.println("We have just received PINGRESP packet");
+    });
+  }
+
+  public void tls(Vertx vertx, String algo) {
+    MqttClientOptions options = new MqttClientOptions();
+    options
+      .setSsl(true)
+      .setTrustOptions(new PemTrustOptions().addCertPath("/path/to/server.crt"))
+      // Algo can be the empty string "" or "HTTPS"
+      .setHostnameVerificationAlgorithm(algo);
+    MqttClient client = MqttClient.create(vertx);
+    client.connect(1883, "mqtt.eclipse.org").onComplete(s -> {
+      client.disconnect();
     });
   }
 }

--- a/src/main/java/io/vertx/mqtt/MqttClientOptions.java
+++ b/src/main/java/io/vertx/mqtt/MqttClientOptions.java
@@ -511,6 +511,12 @@ public class MqttClientOptions extends NetClientOptions {
   }
 
   @Override
+  public MqttClientOptions setHostnameVerificationAlgorithm(String hostnameVerificationAlgorithm) {
+    super.setHostnameVerificationAlgorithm(hostnameVerificationAlgorithm);
+    return this;
+  }
+
+  @Override
   public MqttClientOptions setTrustAll(boolean trustAll) {
     super.setTrustAll(trustAll);
     return this;

--- a/src/test/java/io/vertx/mqtt/test/client/MqttClientSslTest.java
+++ b/src/test/java/io/vertx/mqtt/test/client/MqttClientSslTest.java
@@ -50,15 +50,16 @@ public class MqttClientSslTest {
   public void clientSslTrustAllTest(TestContext context) {
     MqttClientOptions clientOptions = new MqttClientOptions()
       .setSsl(true)
-      .setTrustAll(true);
+      .setTrustAll(true)
+      .setHostnameVerificationAlgorithm("");
 
     MqttClient client = MqttClient.create(vertx, clientOptions);
     client.exceptionHandler(t -> context.assertTrue(false));
 
     this.context = context;
-    Async async = context.async();
-    client.connect(MQTT_SERVER_TLS_PORT, MQTT_SERVER_HOST, s -> client.disconnect(d -> async.countDown()));
-    async.await();
+    client.connect(MQTT_SERVER_TLS_PORT, MQTT_SERVER_HOST)
+      .compose(msg -> client.disconnect())
+      .onComplete(context.asyncAssertSuccess());
   }
 
   @Test
@@ -69,14 +70,15 @@ public class MqttClientSslTest {
 
     MqttClientOptions clientOptions = new MqttClientOptions()
       .setSsl(true)
-      .setTrustStoreOptions(jksOptions);
+      .setTrustStoreOptions(jksOptions)
+      .setHostnameVerificationAlgorithm("");
 
     MqttClient client = MqttClient.create(vertx, clientOptions);
     client.exceptionHandler(t -> context.assertTrue(false));
 
-    Async async = context.async();
-    client.connect(MQTT_SERVER_TLS_PORT, MQTT_SERVER_HOST, s -> client.disconnect(d -> async.countDown()));
-    async.await();
+    client.connect(MQTT_SERVER_TLS_PORT, MQTT_SERVER_HOST)
+      .compose(msg -> client.disconnect())
+      .onComplete(context.asyncAssertSuccess());
   }
 
   @Before


### PR DESCRIPTION
Since the Vert.x `NetClient` now requires the hostname verification algorithm to be set, the example should precisely show how to set it. In addition fix incorrect client TLS tests.