### PR TITLE
Support auth message both client side and server side.

### DIFF
--- a/src/main/asciidoc/index.adoc
+++ b/src/main/asciidoc/index.adoc
@@ -223,6 +223,22 @@ that will be called when the server is really closed.
 {@link examples.VertxMqttServerExamples#example9}
 ----
 
+=== Handling client auth packet/Sending AUTH packet to remote client(Only in MQTT version 5)
+
+After a connection is established between client and server, the client can send an auth packet to server using the
+AUTH message. The {@link io.vertx.mqtt.MqttEndpoint} interface allows to specify a handler for the incoming auth packet
+using the {@link io.vertx.mqtt.MqttEndpoint#authenticationExchangeHandler(io.vertx.core.Handler)} method. Such handler
+receives an instance of the {@link io.vertx.mqtt.messages.MqttAuthenticationExchangeMessage} interface which brings the
+reason code, the authentication method and data. The server could continue to send AUTH packet using
+the {@link io.vertx.mqtt.MqttEndpoint#authenticationExchange(io.vertx.mqtt.messages.MqttAuthenticationExchangeMessage)}
+for authentication or just passed it.
+
+[source,$lang]
+----
+{@link examples.VertxMqttServerExamples#example14}
+----
+
+
 === Automatic clean-up in verticles
 
 If you’re creating MQTT servers from inside verticles, those servers will be automatically closed when the verticle is undeployed.
@@ -294,6 +310,21 @@ Let's take a look at the example:
 {@link examples.VertxMqttClientExamples#example3}
 ----
 In the example we send message to topic with name "temperature".
+
+=== Handling server auth request/Sending AUTH packet to server(Only in MQTT version 5)
+
+After a connection is established between client and server, the client can send an auth request to server using
+the {@link io.vertx.mqtt.MqttClient#authenticationExchange(io.vertx.mqtt.messages.MqttAuthenticationExchangeMessage)}
+for authentication. The Server may return an AUTH packet. The {@link io.vertx.mqtt.MqttClient} interface allows to
+specify a handler for the incoming auth packet using
+the {@link io.vertx.mqtt.MqttClient#authenticationExchangeHandler(io.vertx.core.Handler)} method.
+Such handler receives an instance of the {@link io.vertx.mqtt.messages.MqttAuthenticationExchangeMessage} interface
+which brings the reason code, the authentication method and data.
+
+[source,$lang]
+----
+{@link examples.VertxMqttClientExamples#example10}
+----
 
 === Keep connection with server alive
 In order to keep connection with server you should time to time send something to server otherwise server will close the connection.

--- a/src/main/java/examples/VertxMqttClientExamples.java
+++ b/src/main/java/examples/VertxMqttClientExamples.java
@@ -16,6 +16,7 @@
 
 package examples;
 
+import io.netty.handler.codec.mqtt.MqttProperties;
 import io.netty.handler.codec.mqtt.MqttQoS;
 import io.vertx.core.Handler;
 import io.vertx.core.Vertx;
@@ -24,6 +25,8 @@ import io.vertx.core.net.NetClientOptions;
 import io.vertx.core.net.PemTrustOptions;
 import io.vertx.mqtt.MqttClient;
 import io.vertx.mqtt.MqttClientOptions;
+import io.vertx.mqtt.messages.MqttAuthenticationExchangeMessage;
+import io.vertx.mqtt.messages.codes.MqttAuthenticateReasonCode;
 
 public class VertxMqttClientExamples {
 
@@ -150,6 +153,19 @@ public class VertxMqttClientExamples {
     client.pingResponseHandler(s -> {
       //The handler will be called time to time by default
       System.out.println("We have just received PINGRESP packet");
+    });
+  }
+
+  /**
+   * Example for authenticationExchangeHandler and authenticationExchange method demonstration
+   *
+   * @param client
+   */
+  public void example10(MqttClient client) {
+    client.authenticationExchange(MqttAuthenticationExchangeMessage.create(MqttAuthenticateReasonCode.SUCCESS, MqttProperties.NO_PROPERTIES));
+    client.authenticationExchangeHandler(auth -> {
+      //The handler will be called time to time by default
+      System.out.println("We have just received AUTH packet: " + auth.reasonCode());
     });
   }
 

--- a/src/main/java/examples/VertxMqttServerExamples.java
+++ b/src/main/java/examples/VertxMqttServerExamples.java
@@ -27,6 +27,8 @@ import io.vertx.mqtt.MqttEndpoint;
 import io.vertx.mqtt.MqttServer;
 import io.vertx.mqtt.MqttServerOptions;
 import io.vertx.mqtt.MqttTopicSubscription;
+import io.vertx.mqtt.messages.MqttAuthenticationExchangeMessage;
+import io.vertx.mqtt.messages.codes.MqttAuthenticateReasonCode;
 import io.vertx.mqtt.messages.codes.MqttSubAckReasonCode;
 
 import java.nio.charset.Charset;
@@ -324,5 +326,17 @@ public class VertxMqttServerExamples {
           ar.cause().printStackTrace();
         }
       });
+  }
+
+  /**
+   * Example for authentication exchange
+   * @param endpoint
+   */
+  public void example14(MqttEndpoint endpoint) {
+    endpoint.authenticationExchange(MqttAuthenticationExchangeMessage.create(MqttAuthenticateReasonCode.SUCCESS, MqttProperties.NO_PROPERTIES));
+    // handling auth from client
+    endpoint.authenticationExchangeHandler(auth -> {
+      System.out.println("AUTH packet received from client. code: " + auth.reasonCode());
+    });
   }
 }

--- a/src/main/java/examples/VertxMqttServerExamples.java
+++ b/src/main/java/examples/VertxMqttServerExamples.java
@@ -330,6 +330,7 @@ public class VertxMqttServerExamples {
 
   /**
    * Example for authentication exchange
+   *
    * @param endpoint
    */
   public void example14(MqttEndpoint endpoint) {

--- a/src/main/java/io/vertx/mqtt/MqttClient.java
+++ b/src/main/java/io/vertx/mqtt/MqttClient.java
@@ -24,6 +24,7 @@ import io.vertx.core.Handler;
 import io.vertx.core.Vertx;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.mqtt.impl.MqttClientImpl;
+import io.vertx.mqtt.messages.MqttAuthenticationExchangeMessage;
 import io.vertx.mqtt.messages.MqttConnAckMessage;
 import io.vertx.mqtt.messages.MqttPublishMessage;
 import io.vertx.mqtt.messages.MqttSubAckMessage;
@@ -201,6 +202,23 @@ public interface MqttClient {
    * @return a {@code Future} completed after UNSUBSCRIBE packet sent with packetid
    */
   Future<Integer> unsubscribe(List<String> topics);
+
+  /**
+   * Sets handler which will be called after AUTH packet receiving
+   *
+   * @param authenticationExchangeHandler handler to call
+   * @return current MQTT client instance
+   */
+  @Fluent
+  MqttClient authenticationExchangeHandler(Handler<MqttAuthenticationExchangeMessage> authenticationExchangeHandler);
+
+  /**
+   * Unsubscribe from receiving messages on given list of topic
+   *
+   * @param message authentication exchange message
+   * @return a {@code Future} completed after AUTH packet sent
+   */
+  Future<Void> authenticationExchange(MqttAuthenticationExchangeMessage message);
 
   /**
    * Sets handler which will be called after PINGRESP packet receiving

--- a/src/main/java/io/vertx/mqtt/MqttClient.java
+++ b/src/main/java/io/vertx/mqtt/MqttClient.java
@@ -213,7 +213,7 @@ public interface MqttClient {
   MqttClient authenticationExchangeHandler(Handler<MqttAuthenticationExchangeMessage> authenticationExchangeHandler);
 
   /**
-   * Unsubscribe from receiving messages on given list of topic
+   * It is used for Enhanced Authentication and is able to carry an authentication method and authentication data.
    *
    * @param message authentication exchange message
    * @return a {@code Future} completed after AUTH packet sent

--- a/src/main/java/io/vertx/mqtt/MqttEndpoint.java
+++ b/src/main/java/io/vertx/mqtt/MqttEndpoint.java
@@ -36,6 +36,7 @@ import io.vertx.mqtt.messages.MqttPubRelMessage;
 import io.vertx.mqtt.messages.MqttPublishMessage;
 import io.vertx.mqtt.messages.MqttSubscribeMessage;
 import io.vertx.mqtt.messages.MqttUnsubscribeMessage;
+import io.vertx.mqtt.messages.MqttAuthenticationExchangeMessage;
 import io.vertx.mqtt.messages.codes.MqttDisconnectReasonCode;
 import io.vertx.mqtt.messages.codes.MqttPubAckReasonCode;
 import io.vertx.mqtt.messages.codes.MqttPubCompReasonCode;
@@ -338,6 +339,15 @@ public interface MqttEndpoint {
   MqttEndpoint publishCompletionMessageHandler(Handler<MqttPubCompMessage> handler);
 
   /**
+   * Set the auth handler on the MQTT endpoint. This handler is called when a AUTH message is
+   * received by the remote MQTT client
+   * @param handler the handler
+   * @return a reference to this, so the API can be used fluently
+   */
+  @Fluent
+  MqttEndpoint authenticationExchangeHandler(Handler<MqttAuthenticationExchangeMessage> handler);
+
+  /**
    * Set the pingreq handler on the MQTT endpoint. This handler is called when a PINGREQ
    * message is received by the remote MQTT client. In any case the endpoint sends the
    * PINGRESP internally after executing this handler.
@@ -574,6 +584,15 @@ public interface MqttEndpoint {
    */
   @GenIgnore(GenIgnore.PERMITTED_TYPE)
   Future<Integer> publish(String topic, Buffer payload, MqttQoS qosLevel, boolean isDup, boolean isRetain, int messageId, MqttProperties properties);
+
+
+  /**
+   * Sends the AUTH message to the remote MQTT client
+   * @param message
+   * @return a reference to this, so the API can be used fluently
+   */
+  @Fluent
+  MqttEndpoint authenticationExchange(MqttAuthenticationExchangeMessage message);
 
   /**
    * Sends the PINGRESP message to the remote MQTT client

--- a/src/main/java/io/vertx/mqtt/MqttEndpoint.java
+++ b/src/main/java/io/vertx/mqtt/MqttEndpoint.java
@@ -341,6 +341,7 @@ public interface MqttEndpoint {
   /**
    * Set the auth handler on the MQTT endpoint. This handler is called when a AUTH message is
    * received by the remote MQTT client
+   *
    * @param handler the handler
    * @return a reference to this, so the API can be used fluently
    */
@@ -588,6 +589,7 @@ public interface MqttEndpoint {
 
   /**
    * Sends the AUTH message to the remote MQTT client
+   *
    * @param message
    * @return a reference to this, so the API can be used fluently
    */

--- a/src/main/java/io/vertx/mqtt/impl/MqttServerConnection.java
+++ b/src/main/java/io/vertx/mqtt/impl/MqttServerConnection.java
@@ -180,6 +180,12 @@ public class MqttServerConnection {
           this.handlePubcomp(pubcompVariableHeader.messageId(), MqttPubCompReasonCode.valueOf(pubcompVariableHeader.reasonCode()), pubcompVariableHeader.properties());
           break;
 
+        case AUTH:
+          MqttReasonCodeAndPropertiesVariableHeader header = (MqttReasonCodeAndPropertiesVariableHeader) mqttMessage.variableHeader();
+          MqttAuthenticateReasonCode reasonCode = MqttAuthenticateReasonCode.valueOf(header.reasonCode());
+          this.handleAuth(reasonCode, header.properties());
+          break;
+
         case PINGREQ:
 
           this.handlePingreq();
@@ -410,6 +416,17 @@ public class MqttServerConnection {
     synchronized (this.so) {
       if (this.checkConnected()) {
         this.endpoint.handlePubcomp(pubcompMessageId, code, properties);
+      }
+    }
+  }
+
+  /**
+   * Used internally for handling the auth from the remote MQTT client
+   */
+  void handleAuth(MqttAuthenticateReasonCode reasonCode, MqttProperties properties) {
+    synchronized (this.so) {
+      if (this.checkConnected()) {
+        this.endpoint.handleAuth(reasonCode, properties);
       }
     }
   }

--- a/src/main/java/io/vertx/mqtt/messages/MqttAuthenticationExchangeMessage.java
+++ b/src/main/java/io/vertx/mqtt/messages/MqttAuthenticationExchangeMessage.java
@@ -21,7 +21,7 @@ public interface MqttAuthenticationExchangeMessage {
    * @param properties mqtt properties.
    * @return Vert.x auth message
    */
-  @GenIgnore
+  @GenIgnore(GenIgnore.PERMITTED_TYPE)
   static MqttAuthenticationExchangeMessage create(MqttAuthenticateReasonCode reasonCode, MqttProperties properties) {
     return new MqttAuthenticationExchangeMessageImpl(reasonCode, properties);
   }

--- a/src/main/java/io/vertx/mqtt/messages/MqttAuthenticationExchangeMessage.java
+++ b/src/main/java/io/vertx/mqtt/messages/MqttAuthenticationExchangeMessage.java
@@ -1,0 +1,52 @@
+package io.vertx.mqtt.messages;
+
+import io.netty.handler.codec.mqtt.MqttProperties;
+import io.vertx.codegen.annotations.CacheReturn;
+import io.vertx.codegen.annotations.GenIgnore;
+import io.vertx.codegen.annotations.VertxGen;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.mqtt.messages.codes.MqttAuthenticateReasonCode;
+import io.vertx.mqtt.messages.impl.MqttAuthenticationExchangeMessageImpl;
+
+/**
+ * Represents an MQTT AUTH message
+ */
+@VertxGen
+public interface MqttAuthenticationExchangeMessage {
+
+  /**
+   * Create a concrete instance of a Vert.x auth message
+   *
+   * @param reasonCode authenticate reason code
+   * @param properties mqtt properties.
+   * @return Vert.x auth message
+   */
+  @GenIgnore
+  static MqttAuthenticationExchangeMessage create(MqttAuthenticateReasonCode reasonCode, MqttProperties properties) {
+    return new MqttAuthenticationExchangeMessageImpl(reasonCode, properties);
+  }
+
+  /**
+   * @return authenticate reason code
+   */
+  MqttAuthenticateReasonCode reasonCode();
+
+  /**
+   * @return authenticate method
+   */
+  @CacheReturn
+  String authenticationMethod();
+
+  /**
+   * @return authentication data
+   */
+  @CacheReturn
+  Buffer authenticationData();
+
+  /**
+   * @return MQTT properties
+   */
+  @CacheReturn
+  @GenIgnore(GenIgnore.PERMITTED_TYPE)
+  MqttProperties properties();
+}

--- a/src/main/java/io/vertx/mqtt/messages/codes/MqttAuthenticateReasonCode.java
+++ b/src/main/java/io/vertx/mqtt/messages/codes/MqttAuthenticateReasonCode.java
@@ -6,8 +6,7 @@ public enum MqttAuthenticateReasonCode implements MqttReasonCode {
 
   CONTINUE_AUTHENTICATION((byte) 0x18),
 
-  RE_AUTHENTICATE((byte) 0x19),
-  ;
+  RE_AUTHENTICATE((byte) 0x19);
 
   MqttAuthenticateReasonCode(byte byteValue) {
     this.byteValue = byteValue;

--- a/src/main/java/io/vertx/mqtt/messages/codes/MqttAuthenticateReasonCode.java
+++ b/src/main/java/io/vertx/mqtt/messages/codes/MqttAuthenticateReasonCode.java
@@ -1,0 +1,31 @@
+package io.vertx.mqtt.messages.codes;
+
+public enum MqttAuthenticateReasonCode implements MqttReasonCode {
+
+  SUCCESS((byte) 0x0),
+
+  CONTINUE_AUTHENTICATION((byte) 0x18),
+
+  RE_AUTHENTICATE((byte) 0x19),
+  ;
+
+  MqttAuthenticateReasonCode(byte byteValue) {
+    this.byteValue = byteValue;
+  }
+
+  private final byte byteValue;
+
+  @Override
+  public byte value() {
+    return byteValue;
+  }
+
+  public static MqttAuthenticateReasonCode valueOf(byte b) {
+    for (MqttAuthenticateReasonCode code : MqttAuthenticateReasonCode.values()) {
+      if (code.byteValue == b) {
+        return code;
+      }
+    }
+    throw new IllegalArgumentException("unknown AUTHENTICATE reason code: " + b);
+  }
+}

--- a/src/main/java/io/vertx/mqtt/messages/impl/MqttAuthenticationExchangeMessageImpl.java
+++ b/src/main/java/io/vertx/mqtt/messages/impl/MqttAuthenticationExchangeMessageImpl.java
@@ -1,0 +1,47 @@
+package io.vertx.mqtt.messages.impl;
+
+import io.netty.handler.codec.mqtt.MqttProperties;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.mqtt.messages.MqttAuthenticationExchangeMessage;
+import io.vertx.mqtt.messages.codes.MqttAuthenticateReasonCode;
+
+/**
+ * Represents an MQTT AUTH message
+ */
+public class MqttAuthenticationExchangeMessageImpl implements MqttAuthenticationExchangeMessage {
+
+  private final MqttAuthenticateReasonCode reasonCode;
+
+  private final MqttProperties properties;
+
+  public MqttAuthenticationExchangeMessageImpl(MqttAuthenticateReasonCode reasonCode, MqttProperties properties) {
+    this.reasonCode = reasonCode;
+    this.properties = properties;
+  }
+
+  @Override
+  public MqttAuthenticateReasonCode reasonCode() {
+    return reasonCode;
+  }
+
+  @Override
+  @SuppressWarnings("rawtypes")
+  public String authenticationMethod() {
+    MqttProperties.MqttProperty prop =
+      properties.getProperty(MqttProperties.MqttPropertyType.AUTHENTICATION_METHOD.value());
+    return prop == null ? null : ((MqttProperties.StringProperty) prop).value();
+  }
+
+  @Override
+  @SuppressWarnings("rawtypes")
+  public Buffer authenticationData() {
+    MqttProperties.MqttProperty prop =
+      properties.getProperty(MqttProperties.MqttPropertyType.AUTHENTICATION_DATA.value());
+    return prop == null ? null : Buffer.buffer(((MqttProperties.BinaryProperty) prop).value());
+  }
+
+  @Override
+  public MqttProperties properties() {
+    return properties;
+  }
+}

--- a/src/test/java/io/vertx/mqtt/test/server/Mqtt5ServerAuthTest.java
+++ b/src/test/java/io/vertx/mqtt/test/server/Mqtt5ServerAuthTest.java
@@ -38,7 +38,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.Objects;
 
 /**
- * MQTT server testing about server publish
+ * MQTT server testing about server auth
  */
 public class Mqtt5ServerAuthTest extends MqttServerBaseTest {
 

--- a/src/test/java/io/vertx/mqtt/test/server/Mqtt5ServerAuthTest.java
+++ b/src/test/java/io/vertx/mqtt/test/server/Mqtt5ServerAuthTest.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright 2016 Red Hat Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.vertx.mqtt.test.server;
+
+import io.vertx.core.internal.logging.Logger;
+import io.vertx.core.internal.logging.LoggerFactory;
+import io.vertx.ext.unit.Async;
+import io.vertx.ext.unit.TestContext;
+import io.vertx.mqtt.MqttEndpoint;
+import io.vertx.mqtt.messages.codes.MqttAuthenticateReasonCode;
+import org.eclipse.paho.mqttv5.client.MqttAsyncClient;
+import org.eclipse.paho.mqttv5.client.MqttToken;
+import org.eclipse.paho.mqttv5.client.internal.ClientComms;
+import org.eclipse.paho.mqttv5.client.persist.MemoryPersistence;
+import org.eclipse.paho.mqttv5.common.MqttException;
+
+import org.eclipse.paho.mqttv5.common.packet.MqttProperties;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.lang.reflect.Field;
+import java.nio.charset.StandardCharsets;
+import java.util.Objects;
+
+/**
+ * MQTT server testing about server publish
+ */
+public class Mqtt5ServerAuthTest extends MqttServerBaseTest {
+
+  private static final Logger log = LoggerFactory.getLogger(Mqtt5ServerAuthTest.class);
+
+  private Async async;
+
+  private MqttAuthenticateReasonCode reasonCode;
+  private String authMethod;
+  private String authData;
+
+  @Before
+  public void before(TestContext context) {
+
+    this.setUp(context);
+  }
+
+  @After
+  public void after(TestContext context) {
+
+    this.tearDown(context);
+  }
+
+  @Test
+  public void receiveAuth(TestContext context) {
+    this.reasonCode = MqttAuthenticateReasonCode.CONTINUE_AUTHENTICATION;
+    this.authMethod = "test";
+    this.authData = "test";
+
+    this.async = context.async(1);
+
+    try {
+      MemoryPersistence persistence = new MemoryPersistence();
+      MqttAsyncClient client = new MqttAsyncClient(String.format("tcp://%s:%d", MQTT_SERVER_HOST, MQTT_SERVER_PORT), "12345", persistence);
+      client.connect().waitForCompletion();
+
+      MqttProperties props = new MqttProperties();
+      props.setAuthenticationMethod(authMethod);
+      props.setAuthenticationData(authData.getBytes(StandardCharsets.UTF_8));
+
+      Field senderField = client.getClass().getDeclaredField("comms");
+      senderField.setAccessible(true);
+
+      ClientComms comms = (ClientComms) senderField.get(client);
+      comms.sendNoWait(new MqttAuthPacket(reasonCode.value(), props), new MqttToken(client.getClientId()));
+
+      log.info("send auth packet");
+      this.async.await();
+
+    } catch (MqttException e) {
+      context.fail(e);
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  @Override
+  protected void endpointHandler(MqttEndpoint endpoint, TestContext context) {
+
+    endpoint.authenticationExchangeHandler(auth -> {
+      log.info("recv auth packet");
+      MqttAuthenticateReasonCode code = auth.reasonCode();
+      String method = auth.authenticationMethod();
+      String data = auth.authenticationData().toString();
+      context.assertEquals(code, this.reasonCode);
+      context.assertTrue(Objects.equals(method, this.authMethod));
+      context.assertTrue(Objects.equals(data, this.authData));
+      log.info("test auth pass");
+      async.countDown();
+    });
+    endpoint.accept(false);
+  }
+}

--- a/src/test/java/io/vertx/mqtt/test/server/MqttAuthPacket.java
+++ b/src/test/java/io/vertx/mqtt/test/server/MqttAuthPacket.java
@@ -1,0 +1,23 @@
+package io.vertx.mqtt.test.server;
+
+import org.eclipse.paho.mqttv5.common.MqttException;
+import org.eclipse.paho.mqttv5.common.packet.MqttAuth;
+import org.eclipse.paho.mqttv5.common.packet.MqttProperties;
+
+import java.io.IOException;
+
+/**
+ * Cause the bug of paho mqtt client. It's a workaround solution.
+ * See also: <a href="https://github.com/eclipse/paho.mqtt.java/issues/980">https://github.com/eclipse/paho.mqtt.java/issues/980</a>
+ */
+public class MqttAuthPacket extends MqttAuth {
+
+  public MqttAuthPacket(int returnCode, MqttProperties properties) throws MqttException {
+    super(returnCode, properties);
+  }
+
+  @Override
+  protected byte getMessageInfo() {
+    return 0;
+  }
+}


### PR DESCRIPTION
Motivation:

At the moment of writing, the vertx-mqtt supports all MQTT version 5.0 features except AUTH message which is yet to be implemented. Now I used it to develop my mqtt broker. So, I try to finished this.

Conformance:

Your commits should be signed and you should have signed the Eclipse Contributor Agreement as explained in https://github.com/eclipse/vert.x/blob/master/CONTRIBUTING.md
Please also make sure you adhere to the code style guidelines: https://github.com/vert-x3/wiki/wiki/Vert.x-code-style-guidelines
