### PR TITLE
Fix MqttSubscribeMessage.properties() always be empty

### DIFF
--- a/src/main/java/io/vertx/mqtt/impl/MqttServerConnection.java
+++ b/src/main/java/io/vertx/mqtt/impl/MqttServerConnection.java
@@ -118,7 +118,8 @@ public class MqttServerConnection {
 
           MqttSubscribeMessage mqttSubscribeMessage = MqttSubscribeMessage.create(
             subscribe.variableHeader().messageId(),
-            subscribe.payload().topicSubscriptions());
+            subscribe.payload().topicSubscriptions(),
+            subscribe.idAndPropertiesVariableHeader().properties());
           this.handleSubscribe(mqttSubscribeMessage);
           break;
 
@@ -128,7 +129,8 @@ public class MqttServerConnection {
 
           MqttUnsubscribeMessage mqttUnsubscribeMessage = MqttUnsubscribeMessage.create(
             unsubscribe.variableHeader().messageId(),
-            unsubscribe.payload().topics());
+            unsubscribe.payload().topics(),
+            unsubscribe.idAndPropertiesVariableHeader().properties());
           this.handleUnsubscribe(mqttUnsubscribeMessage);
           break;
 

--- a/src/test/java/io/vertx/mqtt/test/server/Mqtt5ServerUnsubscribeTest.java
+++ b/src/test/java/io/vertx/mqtt/test/server/Mqtt5ServerUnsubscribeTest.java
@@ -24,10 +24,13 @@ import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
 import io.vertx.mqtt.MqttEndpoint;
 import io.vertx.mqtt.messages.codes.MqttUnsubAckReasonCode;
+import org.eclipse.paho.mqttv5.client.IMqttToken;
+import org.eclipse.paho.mqttv5.client.MqttAsyncClient;
 import org.eclipse.paho.mqttv5.client.MqttClient;
 import org.eclipse.paho.mqttv5.client.persist.MemoryPersistence;
 import org.eclipse.paho.mqttv5.common.MqttException;
 import org.eclipse.paho.mqttv5.common.packet.MqttReturnCode;
+import org.eclipse.paho.mqttv5.common.packet.UserProperty;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -51,6 +54,9 @@ public class Mqtt5ServerUnsubscribeTest extends MqttServerBaseTest {
 
   private static final String MQTT_REASON_STRING = "because I've said so";
 
+  private static final String USER_PROPERTY_KEY = "key";
+  private static final String USER_PROPERTY_VALUE = "value";
+
   @Before
   public void before(TestContext context) {
 
@@ -68,15 +74,22 @@ public class Mqtt5ServerUnsubscribeTest extends MqttServerBaseTest {
 
     try {
       MemoryPersistence persistence = new MemoryPersistence();
-      MqttClient client = new MqttClient(String.format("tcp://%s:%d", MQTT_SERVER_HOST, MQTT_SERVER_PORT), "12345", persistence);
-      client.connect();
+      MqttAsyncClient client = new MqttAsyncClient(String.format("tcp://%s:%d", MQTT_SERVER_HOST, MQTT_SERVER_PORT), "12345", persistence);
+      IMqttToken token = client.connect();
+      token.waitForCompletion();
 
       expectedReasonCodes = Collections.singletonList(MqttUnsubAckReasonCode.SUCCESS);
       String[] topics = new String[]{MQTT_TOPIC};
       int[] qos = new int[]{0};
-      client.subscribe(topics, qos);
+      token = client.subscribe(topics, qos);
+      token.waitForCompletion();
 
-      client.unsubscribe(topics);
+      org.eclipse.paho.mqttv5.common.packet.MqttProperties mqttProperties = new org.eclipse.paho.mqttv5.common.packet.MqttProperties();
+      List<UserProperty> userProperties = new ArrayList<>();
+      userProperties.add(new UserProperty(USER_PROPERTY_KEY, USER_PROPERTY_VALUE));
+      mqttProperties.setUserProperties(userProperties);
+      token = client.unsubscribe(topics, null, null, mqttProperties);
+      token.waitForCompletion();
 
       context.assertTrue(true);
 
@@ -118,6 +131,12 @@ public class Mqtt5ServerUnsubscribeTest extends MqttServerBaseTest {
       endpoint.subscribeAcknowledge(subscribe.messageId(), qos);
 
     }).unsubscribeHandler(unsubscribe -> {
+
+      if(expectedReasonCodes.get(0) == MqttUnsubAckReasonCode.SUCCESS) {
+        MqttProperties.UserProperties userProperties = (MqttProperties.UserProperties) unsubscribe.properties().getProperty(MqttProperties.MqttPropertyType.USER_PROPERTY.value());
+        context.assertEquals(userProperties.value().get(0).key, USER_PROPERTY_KEY);
+        context.assertEquals(userProperties.value().get(0).value, USER_PROPERTY_VALUE);
+      }
 
       MqttProperties props = new MqttProperties();
       if(expectedReasonCodes.get(0) != MqttUnsubAckReasonCode.SUCCESS) {


### PR DESCRIPTION
Motivation:

MqttSubscribeMessage.properties() always be empty, I am trying to fix this bug #249 , also included some unit test code.

Conformance:

Your commits should be signed and you should have signed the Eclipse Contributor Agreement as explained in https://github.com/eclipse/vert.x/blob/master/CONTRIBUTING.md
Please also make sure you adhere to the code style guidelines: https://github.com/vert-x3/wiki/wiki/Vert.x-code-style-guidelines
