### PR TITLE
Fix MqttSubscribeMessage.properties() always be empty

### DIFF
--- a/src/main/java/io/vertx/mqtt/impl/MqttServerConnection.java
+++ b/src/main/java/io/vertx/mqtt/impl/MqttServerConnection.java
@@ -128,7 +128,8 @@ public class MqttServerConnection {
 
           MqttSubscribeMessage mqttSubscribeMessage = MqttSubscribeMessage.create(
             subscribe.variableHeader().messageId(),
-            subscribe.payload().topicSubscriptions());
+            subscribe.payload().topicSubscriptions(),
+            subscribe.idAndPropertiesVariableHeader().properties());
           this.handleSubscribe(mqttSubscribeMessage);
           break;
 
@@ -138,7 +139,8 @@ public class MqttServerConnection {
 
           MqttUnsubscribeMessage mqttUnsubscribeMessage = MqttUnsubscribeMessage.create(
             unsubscribe.variableHeader().messageId(),
-            unsubscribe.payload().topics());
+            unsubscribe.payload().topics(),
+            unsubscribe.idAndPropertiesVariableHeader().properties());
           this.handleUnsubscribe(mqttUnsubscribeMessage);
           break;
 

--- a/src/test/java/io/vertx/mqtt/test/server/Mqtt5ServerSubscribeTest.java
+++ b/src/test/java/io/vertx/mqtt/test/server/Mqtt5ServerSubscribeTest.java
@@ -29,7 +29,8 @@ import io.vertx.mqtt.MqttEndpoint;
 import io.vertx.mqtt.MqttTopicSubscription;
 import io.vertx.mqtt.messages.codes.MqttReasonCode;
 import io.vertx.mqtt.messages.codes.MqttSubAckReasonCode;
-import org.eclipse.paho.mqttv5.client.MqttClient;
+import org.eclipse.paho.mqttv5.client.IMqttToken;
+import org.eclipse.paho.mqttv5.client.MqttAsyncClient;
 import org.eclipse.paho.mqttv5.client.persist.MemoryPersistence;
 import org.eclipse.paho.mqttv5.common.MqttException;
 import org.eclipse.paho.mqttv5.common.MqttSubscription;
@@ -61,6 +62,7 @@ public class Mqtt5ServerSubscribeTest extends MqttServerBaseTest {
   private static final String MQTT_TOPIC = "/my_topic";
   private static final String MQTT_TOPIC_FAILURE = "/my_topic/failure";
   private static final String MQTT_FAILURE_REASON = "test reason";
+  private static final int SUBSCRIPTION_IDENTIFIER = 42;
 
   @Before
   public void before(TestContext context) {
@@ -104,8 +106,9 @@ public class Mqtt5ServerSubscribeTest extends MqttServerBaseTest {
 
     try {
       MemoryPersistence persistence = new MemoryPersistence();
-      MqttClient client = new MqttClient(String.format("tcp://%s:%d", MQTT_SERVER_HOST, MQTT_SERVER_PORT), "12345", persistence);
-      client.connect();
+      MqttAsyncClient client = new MqttAsyncClient(String.format("tcp://%s:%d", MQTT_SERVER_HOST, MQTT_SERVER_PORT), "12345", persistence);
+      IMqttToken token = client.connect();
+      token.waitForCompletion();
 
       MqttSubscription subscription = new MqttSubscription(topic, expectedQos);
       this.requestedQos = expectedQos;
@@ -115,7 +118,10 @@ public class Mqtt5ServerSubscribeTest extends MqttServerBaseTest {
       this.requestedNoLocal = noLocal;
       this.requestedRetainAsPublished = retainAsPublished;
       this.requestedRetainHandling = retainHandling;
-      client.subscribe(new MqttSubscription[]{ subscription });
+      org.eclipse.paho.mqttv5.common.packet.MqttProperties mqttProperties = new org.eclipse.paho.mqttv5.common.packet.MqttProperties();
+      mqttProperties.setSubscriptionIdentifier(SUBSCRIPTION_IDENTIFIER);
+      token = client.subscribe(new MqttSubscription[]{ subscription }, null, null, mqttProperties);
+      token.waitForCompletion();
 
       this.async.await();
     } catch (MqttException e) {
@@ -173,6 +179,7 @@ public class Mqtt5ServerSubscribeTest extends MqttServerBaseTest {
       context.assertEquals(requestedNoLocal, subscription.subscriptionOption().isNoLocal());
       context.assertEquals(requestedRetainAsPublished, subscription.subscriptionOption().isRetainAsPublished());
       context.assertEquals(requestedRetainHandling, subscription.subscriptionOption().retainHandling().value());
+      context.assertEquals(SUBSCRIPTION_IDENTIFIER, subscribe.properties().getProperty(MqttProperties.MqttPropertyType.SUBSCRIPTION_IDENTIFIER.value()).value());
 
       List<MqttSubAckReasonCode> reasonCodes = new ArrayList<>();
       MqttProperties subackProperties = new MqttProperties();


### PR DESCRIPTION
MqttSubscribeMessage.properties() always be empty, I am trying to fix this bug https://github.com/vert-x3/vertx-mqtt/issues/249 , also included some unit test code.