### PR TITLE
Fix flaky connackNotOk test by explicitly closing server

### DIFF
--- a/src/test/java/io/vertx/mqtt/it/MqttClientConnectIT.java
+++ b/src/test/java/io/vertx/mqtt/it/MqttClientConnectIT.java
@@ -119,6 +119,9 @@ public class MqttClientConnectIT extends MqttClientBaseIT {
         MqttConnectionException connEx = (MqttConnectionException) err;
         assertEquals(connEx.code(), MqttConnectReturnCode.CONNECTION_REFUSED_SERVER_UNAVAILABLE);
         assertFalse(client.isConnected());
+        // Ensure server and Vertx are closed
+        server.close().onComplete(context.asyncAssertSuccess());
+        vertx.close();
       }));
   }
 }


### PR DESCRIPTION
Fix OD flakiness by closing Vert.x MQTT server after `connackNotOk` test in `MqttClientConnectIT`

This PR closes the MQTT server after the `connackNotOk` test to prevent it from remaining active. Previously, the server was still running after the test finished, causing other tests (e.g., `testValidClientIdentifier` in `MqttServerClientIdentifierTest`) to fail when they couldn't start a new server instance. This OD flakiness was detected by iDFlakies.

```
{
    "dts": [
        {
            "name": "io.vertx.mqtt.test.server.MqttServerClientIdentifierTest.testValidClientIdentifier",
            "intended": {
                "order": [
                    "io.vertx.mqtt.it.MqttClientConnectIT.connackNotOk"
                ],
                "result": "ERROR",
                "testRunId": "1730911774733-f1313efd-d311-41b9-b99e-e99db69d4f7c"
            },
            "revealed": {
                "order": [],
                "result": "PASS",
                "testRunId": "1730911782385-e91a008c-d3a6-49b5-bcdc-8136b7868a3f"
            },
            "type": "OD"
        }
    ]
}
```