### PR TITLE
Pause/Resume read from Socket - branch 5.0

### DIFF
--- a/src/main/java/io/vertx/mqtt/MqttClient.java
+++ b/src/main/java/io/vertx/mqtt/MqttClient.java
@@ -260,6 +260,23 @@ public interface MqttClient {
   MqttClient ping();
 
   /**
+   * Pause the reading channel, so no new byte are read from the server.
+   * Available after connection is established.
+   * <p>
+   * This simply delegates to {@link io.vertx.core.net.NetSocket#pause()}.
+   */
+  void pause();
+
+
+  /**
+   * Resume the reading channel. see {@link #pause()}
+   * Available after connection is established.
+   * <p>
+   * This simply delegates to {@link io.vertx.core.net.NetSocket#resume()}.
+   */
+  void resume();
+
+  /**
    * @return the client identifier
    */
   String clientId();

--- a/src/main/java/io/vertx/mqtt/impl/MqttClientImpl.java
+++ b/src/main/java/io/vertx/mqtt/impl/MqttClientImpl.java
@@ -665,6 +665,16 @@ public class MqttClientImpl implements MqttClient {
   }
 
   @Override
+  public void pause() {
+    connection.pause();
+  }
+
+  @Override
+  public void resume() {
+    connection.resume();
+  }
+
+  @Override
   public synchronized String clientId() {
     return this.options.getClientId();
   }

--- a/src/test/java/io/vertx/mqtt/it/MqttClientBaseIT.java
+++ b/src/test/java/io/vertx/mqtt/it/MqttClientBaseIT.java
@@ -30,7 +30,7 @@ import org.testcontainers.utility.DockerImageName;
 public abstract class MqttClientBaseIT {
 
   @Rule
-  public GenericContainer redis = new GenericContainer(DockerImageName.parse("ansi/mosquitto"))
+  public GenericContainer mosquitto = new GenericContainer(DockerImageName.parse("ansi/mosquitto"))
     .withExposedPorts(1883);
 
   protected int port;
@@ -38,7 +38,7 @@ public abstract class MqttClientBaseIT {
 
   @Before
   public void setUp() {
-    port = redis.getMappedPort(1883);
-    host = redis.getHost();
+    port = mosquitto.getMappedPort(1883);
+    host = mosquitto.getHost();
   }
 }

--- a/src/test/java/io/vertx/mqtt/it/MqttClientPublishPauseIT.java
+++ b/src/test/java/io/vertx/mqtt/it/MqttClientPublishPauseIT.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2016 Red Hat Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.vertx.mqtt.it;
+
+import io.netty.handler.codec.mqtt.MqttQoS;
+import io.vertx.core.Vertx;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.core.internal.logging.Logger;
+import io.vertx.core.internal.logging.LoggerFactory;
+import io.vertx.ext.unit.Async;
+import io.vertx.ext.unit.TestContext;
+import io.vertx.ext.unit.junit.VertxUnitRunner;
+import io.vertx.mqtt.MqttClient;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import static org.junit.Assert.assertTrue;
+
+/**
+ * MQTT client testing on publishing messages
+ */
+@RunWith(VertxUnitRunner.class)
+public class MqttClientPublishPauseIT extends MqttClientBaseIT {
+
+  private static final Logger log = LoggerFactory.getLogger(MqttClientPublishPauseIT.class);
+
+  private static final String MQTT_TOPIC = "/my_topic";
+  private static final String MQTT_MESSAGE = "Hello Vert.x MQTT Client";
+
+  private int messageCount = 0;
+
+  @Test
+  public void testPauseResume(TestContext context) throws InterruptedException {
+
+    Async async = context.async();
+    Vertx vertx = Vertx.vertx();
+    MqttClient client = MqttClient.create(vertx);
+
+    client.publishHandler(mess -> {
+      log.info("Received message id = " + mess.messageId());
+      messageCount++;
+    });
+
+    client.connect(port, host).onComplete(context.asyncAssertSuccess(v -> {
+
+      client.subscribe(MQTT_TOPIC, 0);
+
+      log.info("Pause reading");
+      client.pause();
+
+      client.publish(MQTT_TOPIC,
+          Buffer.buffer(MQTT_MESSAGE.getBytes()),
+          MqttQoS.AT_LEAST_ONCE, false, false);
+
+      vertx.setTimer(2_000, event -> {
+        log.info("Resume reading");
+        client.resume();
+      });
+
+    }));
+
+    // wait for 5 seconds to receive the message after resume
+    vertx.setTimer(1_000, event -> {
+      log.info("Asserting not message received");
+      // should receive no messages during the pause
+      context.assertTrue(messageCount == 0);
+    });
+
+    // wait for 15 seconds to receive the message after resume
+    vertx.setTimer(3_000, event -> {
+      log.info("Asserting receiving message received during the pause");
+      // should receive only one message after resume
+      context.assertTrue(messageCount == 1);
+      client.disconnect();
+      async.complete();
+    });
+
+    async.await();
+
+  }
+
+}


### PR DESCRIPTION
PR for the old https://github.com/vert-x3/vertx-mqtt/issues/6 :) linked with PR https://github.com/vert-x3/vertx-mqtt/pull/261

I want to pause reading from the socket to avoid being overwhelmed by QoS 0 messages.
When reading is paused, incoming data accumulates in the TCP receive buffer. As the buffer fills up, the TCP stack advertises a reduced window size (eventually a zero window) to the broker, applying backpressure at the TCP level.

At that point, outgoing data may accumulate in the broker’s socket send buffer until its limits are reached. Depending on the broker implementation and configuration, QoS 0 messages that cannot be written may be buffered or dropped.
