### PR TITLE
Fix Inverted condition on isPaused method

### DIFF
--- a/src/main/java/io/vertx/mqtt/impl/MqttClientImpl.java
+++ b/src/main/java/io/vertx/mqtt/impl/MqttClientImpl.java
@@ -731,7 +731,7 @@ public class MqttClientImpl implements MqttClient {
   }
 
   public synchronized boolean isPaused() {
-    return connOption.isAutoRead();
+    return !connOption.isAutoRead();
   }
 
   @Override


### PR DESCRIPTION
#261 (Pause/Resume read from Socket - branch 4.x) introduce a bug in https://github.com/vert-x3/vertx-mqtt/blob/acb3c437b790bf2e2cddf57c95c62c2ff3a02f0c/src/main/java/io/vertx/mqtt/impl/MqttClientImpl.java#L733-L734 
The condition must be negated.