### PR TITLE
Add recvByteBufAllocatorSize to MqttClientOptions and update converter

### DIFF
--- a/src/main/generated/io/vertx/mqtt/MqttClientOptionsConverter.java
+++ b/src/main/generated/io/vertx/mqtt/MqttClientOptionsConverter.java
@@ -70,6 +70,11 @@ public class MqttClientOptionsConverter {
             obj.setPassword((String)member.getValue());
           }
           break;
+        case "recvByteBufAllocatorSize":
+          if (member.getValue() instanceof Number) {
+            obj.setRecvByteBufAllocatorSize(((Number)member.getValue()).intValue());
+          }
+          break;
         case "username":
           if (member.getValue() instanceof String) {
             obj.setUsername((String)member.getValue());
@@ -123,6 +128,7 @@ public class MqttClientOptionsConverter {
     if (obj.getPassword() != null) {
       json.put("password", obj.getPassword());
     }
+    json.put("recvByteBufAllocatorSize", obj.getRecvByteBufAllocatorSize());
     if (obj.getUsername() != null) {
       json.put("username", obj.getUsername());
     }

--- a/src/main/java/io/vertx/mqtt/MqttClientOptions.java
+++ b/src/main/java/io/vertx/mqtt/MqttClientOptions.java
@@ -45,6 +45,7 @@ public class MqttClientOptions extends NetClientOptions {
   public static final int DEFAULT_MAX_MESSAGE_SIZE = -1;
   public static final int DEFAULT_ACK_TIMEOUT = -1;
   public static final boolean DEFAULT_AUTO_ACK = true;
+  public static final int DEFAULT_RECV_BYTE_BUF_ALLOCATOR_SIZE = -1;
 
   private String clientId;
   private String username;
@@ -62,6 +63,7 @@ public class MqttClientOptions extends NetClientOptions {
   private int maxMessageSize = DEFAULT_MAX_MESSAGE_SIZE;
   private int ackTimeout = DEFAULT_ACK_TIMEOUT;
   private boolean autoAck = DEFAULT_AUTO_ACK;
+  private int recvByteBufAllocatorSize = DEFAULT_RECV_BYTE_BUF_ALLOCATOR_SIZE;
 
   /**
    * Default constructor
@@ -83,6 +85,7 @@ public class MqttClientOptions extends NetClientOptions {
     this.maxMessageSize = DEFAULT_MAX_MESSAGE_SIZE;
     this.ackTimeout = DEFAULT_ACK_TIMEOUT;
     this.autoAck = DEFAULT_AUTO_ACK;
+    this.recvByteBufAllocatorSize = DEFAULT_RECV_BYTE_BUF_ALLOCATOR_SIZE;
   }
 
   /**
@@ -122,6 +125,7 @@ public class MqttClientOptions extends NetClientOptions {
     this.maxMessageSize = other.maxMessageSize;
     this.ackTimeout = other.ackTimeout;
     this.autoAck = other.autoAck;
+    this.recvByteBufAllocatorSize = other.recvByteBufAllocatorSize;
   }
 
   /**
@@ -430,6 +434,25 @@ public class MqttClientOptions extends NetClientOptions {
    */
   public void setAutoAck(boolean autoAck) {
     this.autoAck = autoAck;
+  }
+
+  /**
+   * @return the size for the FixedRecvByteBufAllocator, or -1 if not set
+   */
+  public int getRecvByteBufAllocatorSize() {
+    return recvByteBufAllocatorSize;
+  }
+
+  /**
+   * Set the size for the FixedRecvByteBufAllocator used on the channel.
+   * Use -1 (default) to leave the allocator unchanged.
+   *
+   * @param recvByteBufAllocatorSize the fixed buffer size in bytes, or -1 to disable
+   * @return current options instance
+   */
+  public MqttClientOptions setRecvByteBufAllocatorSize(int recvByteBufAllocatorSize) {
+    this.recvByteBufAllocatorSize = recvByteBufAllocatorSize;
+    return this;
   }
 
   /**

--- a/src/main/java/io/vertx/mqtt/impl/MqttClientImpl.java
+++ b/src/main/java/io/vertx/mqtt/impl/MqttClientImpl.java
@@ -21,6 +21,7 @@ import io.netty.buffer.Unpooled;
 import io.netty.channel.ChannelConfig;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelPipeline;
+import io.netty.channel.FixedRecvByteBufAllocator;
 import io.netty.handler.codec.DecoderResult;
 import io.netty.handler.codec.mqtt.*;
 import io.netty.handler.timeout.IdleState;
@@ -248,6 +249,9 @@ public class MqttClientImpl implements MqttClient {
           synchronized (MqttClientImpl.this) {
             this.connection = soi;
             this.connOption = soi.channelHandlerContext().channel().config();
+            if (options.getRecvByteBufAllocatorSize() != -1) {
+              this.connOption.setRecvByteBufAllocator(new FixedRecvByteBufAllocator(options.getRecvByteBufAllocatorSize()));
+            }
           }
 
           soi.messageHandler(msg -> this.handleMessage(soi.channelHandlerContext(), msg));


### PR DESCRIPTION
I want the ability to set RecvByteBufAllocatorSize to control how many bytes the  MQTT Decoder can process (to create MQTT Messages) after pausing the reads (autoread #261).

See also https://github.com/smallrye/smallrye-reactive-messaging/pull/3378