### PR TITLE
Fix MQTT-over-WebSocket without compression

### DIFF
--- a/src/main/java/io/vertx/mqtt/impl/MqttServerImpl.java
+++ b/src/main/java/io/vertx/mqtt/impl/MqttServerImpl.java
@@ -192,14 +192,16 @@ public class MqttServerImpl implements MqttServer {
       pipeline.addAfter("httpServerCodec", "aggregator", new HttpObjectAggregator(maxFrameSize));
 
       List<WebSocketServerExtensionHandshaker> extensionHandshakers = createExtensionHandshakers();
+      String webSocketHandlerBase = "aggregator";
 
       if (!extensionHandshakers.isEmpty()) {
         WebSocketServerExtensionHandler extensionHandler = new WebSocketServerExtensionHandler(
           extensionHandshakers.toArray(new WebSocketServerExtensionHandshaker[0]));
-        pipeline.addAfter("aggregator", "webSocketExtensionHandler", extensionHandler);
+        pipeline.addAfter(webSocketHandlerBase, "webSocketExtensionHandler", extensionHandler);
+        webSocketHandlerBase = "webSocketExtensionHandler";
       }
 
-      pipeline.addAfter("webSocketExtensionHandler", "webSocketHandler",
+      pipeline.addAfter(webSocketHandlerBase, "webSocketHandler",
         new WebSocketServerProtocolHandler("/mqtt", MQTT_SUBPROTOCOL_CSV_LIST, !extensionHandshakers.isEmpty(), maxFrameSize, 10000L));
 
       pipeline.addAfter("webSocketHandler", "bytebuf2wsEncoder", new ByteBufToWebSocketFrameEncoder());

--- a/src/test/java/io/vertx/mqtt/test/server/MqttServerWebSocketTest.java
+++ b/src/test/java/io/vertx/mqtt/test/server/MqttServerWebSocketTest.java
@@ -181,4 +181,30 @@ public class MqttServerWebSocketTest {
 
 
   }
+
+  @Test
+  public void testWebSocketConnectWithCompressionDisabled(TestContext context) {
+    MqttServerOptions options = new MqttServerOptions()
+      .setHost(MQTT_SERVER_HOST)
+      .setPort(MQTT_SERVER_PORT)
+      .setUseWebSocket(true)
+      .setPerFrameWebSocketCompressionSupported(false)
+      .setPerMessageWebSocketCompressionSupported(false);
+    MqttServer server = MqttServer.create(this.vertx, options);
+    Async done = context.async();
+    server.endpointHandler(endpoint -> {
+      endpoint.accept(false);
+      done.complete();
+    });
+    Async listen = context.async();
+    server.listen().onComplete(context.asyncAssertSuccess(s -> listen.complete()));
+    listen.awaitSuccess(15_000);
+    MemoryPersistence persistence = new MemoryPersistence();
+    try (MqttClient client = new MqttClient(String.format("ws://%s:%d", MQTT_SERVER_HOST, MQTT_SERVER_PORT), "compression-disabled", persistence)) {
+      client.connect();
+      client.disconnect();
+    } catch (MqttException e) {
+      context.fail(e);
+    }
+  }
 }


### PR DESCRIPTION
Motivation:

Fixes #271.

MQTT-over-WebSocket fails with WebSocket enabled and both compression options disabled.
In that case, `webSocketExtensionHandler` is not added to the pipeline, but `webSocketHandler` is still added after it, causing:
`java.util.NoSuchElementException: webSocketExtensionHandler`

Add `webSocketHandler` after `webSocketExtensionHandler` when it exists, otherwise after the HTTP aggregator.
Added a regression test for the disabled-compression case.  


Conformance:
I have signed the Eclipse Contributor Agreement.