### PR TITLE
Reject messageId 0 for QoS 1/2 server-sent PUBLISH packets (4.x branch)

### DIFF
--- a/src/main/java/io/vertx/mqtt/impl/MqttEndpointImpl.java
+++ b/src/main/java/io/vertx/mqtt/impl/MqttEndpointImpl.java
@@ -579,6 +579,9 @@ public class MqttEndpointImpl implements MqttEndpoint {
     if (messageId > MAX_MESSAGE_ID || messageId < 0) {
       throw new IllegalArgumentException("messageId must be non-negative integer not larger than " + MAX_MESSAGE_ID);
     }
+    if ((qosLevel == MqttQoS.AT_LEAST_ONCE || qosLevel == MqttQoS.EXACTLY_ONCE) && messageId == 0) {
+      throw new IllegalArgumentException("messageId must be > 0 for QoS 1 or 2");
+    }
 
     MqttFixedHeader fixedHeader =
       new MqttFixedHeader(MqttMessageType.PUBLISH, isDup, qosLevel, isRetain, 0);

--- a/src/test/java/io/vertx/mqtt/test/server/Mqtt5ServerPublishTest.java
+++ b/src/test/java/io/vertx/mqtt/test/server/Mqtt5ServerPublishTest.java
@@ -55,7 +55,7 @@ public class Mqtt5ServerPublishTest extends MqttServerBaseTest {
   private String message;
   private MqttProperties properties;
 
-  private AtomicInteger nextMessageId = new AtomicInteger(0);
+  private AtomicInteger nextMessageId = new AtomicInteger(1);
 
   private AtomicReference<org.eclipse.paho.mqttv5.common.packet.MqttProperties> lastMessageProperties = new AtomicReference<>(null);
 

--- a/src/test/java/io/vertx/mqtt/test/server/MqttServerPublishTest.java
+++ b/src/test/java/io/vertx/mqtt/test/server/MqttServerPublishTest.java
@@ -16,6 +16,7 @@
 
 package io.vertx.mqtt.test.server;
 
+import io.netty.handler.codec.mqtt.MqttQoS;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.impl.logging.Logger;
 import io.vertx.core.impl.logging.LoggerFactory;
@@ -44,6 +45,8 @@ public class MqttServerPublishTest extends MqttServerBaseTest {
   private Async async;
 
   private static final String MQTT_TOPIC = "/my_topic";
+  private static final String MQTT_TOPIC_ZERO_MESSAGE_ID = "/my_topic_zero_message_id";
+  private static final String MQTT_TOPIC_INVALID_MESSAGE_ID = "/my_topic_invalid_message_id";
   private static final String MQTT_MESSAGE = "Hello Vert.x MQTT Server";
 
   private String topic;
@@ -77,6 +80,21 @@ public class MqttServerPublishTest extends MqttServerBaseTest {
   public void publishQos2(TestContext context) {
 
     this.publish(context, MQTT_TOPIC, MQTT_MESSAGE, 2);
+  }
+
+  @Test
+  public void publishQos0WithZeroMessageId(TestContext context) {
+    this.publish(context, MQTT_TOPIC_ZERO_MESSAGE_ID, MQTT_MESSAGE, 0);
+  }
+
+  @Test
+  public void publishQos1WithZeroMessageId(TestContext context) {
+    this.publishWithInvalidMessageId(context, 1);
+  }
+
+  @Test
+  public void publishQos2WithZeroMessageId(TestContext context) {
+    this.publishWithInvalidMessageId(context, 2);
   }
 
   private void publish(TestContext context, String topic, String message, int qos) {
@@ -114,6 +132,22 @@ public class MqttServerPublishTest extends MqttServerBaseTest {
     }
   }
 
+  private void publishWithInvalidMessageId(TestContext context, int qos) {
+    this.message = MQTT_MESSAGE;
+    this.async = context.async();
+
+    try {
+      MemoryPersistence persistence = new MemoryPersistence();
+      MqttClient client = new MqttClient(String.format("tcp://%s:%d", MQTT_SERVER_HOST, MQTT_SERVER_PORT), "12345", persistence);
+      client.connect();
+      client.subscribe(MQTT_TOPIC_INVALID_MESSAGE_ID, qos);
+
+      this.async.awaitSuccess(15000);
+    } catch (MqttException e) {
+      context.fail(e);
+    }
+  }
+
   @Override
   protected void endpointHandler(MqttEndpoint endpoint, TestContext context) {
 
@@ -125,7 +159,21 @@ public class MqttServerPublishTest extends MqttServerBaseTest {
           .map(MqttTopicSubscription::qualityOfService)
           .collect(Collectors.toList()));
 
-      endpoint.publish(this.topic, Buffer.buffer(this.message), subscribe.topicSubscriptions().get(0).qualityOfService(), false, false, publishSent -> {
+      MqttTopicSubscription subscription = subscribe.topicSubscriptions().get(0);
+      String topicName = subscription.topicName();
+      MqttQoS qosLevel = subscription.qualityOfService();
+
+      if (MQTT_TOPIC_INVALID_MESSAGE_ID.equals(topicName)) {
+        publishInvalidMessageId(endpoint, context, qosLevel);
+        return;
+      }
+
+      if (MQTT_TOPIC_ZERO_MESSAGE_ID.equals(topicName)) {
+        publishZeroMessageId(endpoint, context, qosLevel);
+        return;
+      }
+
+      endpoint.publish(this.topic, Buffer.buffer(this.message), qosLevel, false, false, publishSent -> {
         context.assertTrue(publishSent.succeeded());
         this.async.complete();
       });
@@ -143,5 +191,23 @@ public class MqttServerPublishTest extends MqttServerBaseTest {
     });
 
     endpoint.accept(false);
+  }
+
+  private void publishZeroMessageId(MqttEndpoint endpoint, TestContext context, MqttQoS qosLevel) {
+    endpoint.publish(this.topic, Buffer.buffer(this.message), qosLevel, false, false, 0)
+      .onComplete(context.asyncAssertSuccess(messageId -> {
+        context.assertEquals(0, messageId);
+        this.async.complete();
+      }));
+  }
+
+  private void publishInvalidMessageId(MqttEndpoint endpoint, TestContext context, MqttQoS qosLevel) {
+    try {
+      endpoint.publish(MQTT_TOPIC_INVALID_MESSAGE_ID, Buffer.buffer(this.message), qosLevel, false, false, 0);
+      context.fail("Expected zero messageId to be rejected for " + qosLevel);
+    } catch (IllegalArgumentException e) {
+      context.assertEquals("messageId must be > 0 for QoS 1 or 2", e.getMessage());
+      this.async.complete();
+    }
   }
 }


### PR DESCRIPTION
Motivation:

Backport of #280 for the 4.x branch.

This applies the same server-side PUBLISH validation from the master branch. When callers use the explicit message ID publish overload, QoS 1 and QoS 2 now reject `messageId == 0`.

QoS 0 behavior is unchanged.

Conformance:

I have signed the Eclipse Contributor Agreement.