### PR TITLE
Add missing publish/publishRelease method that can use an identifier as argument.

### DIFF
--- a/src/main/java/io/vertx/mqtt/MqttClient.java
+++ b/src/main/java/io/vertx/mqtt/MqttClient.java
@@ -98,6 +98,27 @@ public interface MqttClient {
   Future<Integer> publish(String topic, Buffer payload, MqttQoS qosLevel, boolean isDup, boolean isRetain);
 
   /**
+   * Sends the PUBLISH message to the remote MQTT server
+   *
+   * @param id       the message ID
+   * @param topic    topic on which the message is published
+   * @param payload  message payload
+   * @param qosLevel QoS level
+   * @param isDup    if the message is a duplicate
+   * @param isRetain if the message needs to be retained
+   * @return a {@code Future} completed after PUBLISH packet sent with packetid (not when QoS 0)
+   */
+  Future<Integer> publish(int id, String topic, Buffer payload, MqttQoS qosLevel, boolean isDup, boolean isRetain);
+
+  /**
+   * Sends the PUBREL message to the remote MQTT server. This can be used when a PUBREL message expires
+   *
+   * @param publishMessageId identifier of the PUBLISH message to acknowledge
+   * @return a reference to this, so the API can be used fluently
+   */
+  Future<Void> publishRelease(int publishMessageId);
+
+  /**
    * Sets a handler which will be called each time the publishing of a message has been completed.
    * <p>
    * For a message that has been published using

--- a/src/main/java/io/vertx/mqtt/MqttClientOptions.java
+++ b/src/main/java/io/vertx/mqtt/MqttClientOptions.java
@@ -406,8 +406,9 @@ public class MqttClientOptions extends NetClientOptions {
    * (default is true)
    * @param autoAck
    */
-  public void setAutoAck(boolean autoAck) {
+  public MqttClientOptions setAutoAck(boolean autoAck) {
     this.autoAck = autoAck;
+    return this;
   }
 
   /**

--- a/src/main/java/io/vertx/mqtt/MqttException.java
+++ b/src/main/java/io/vertx/mqtt/MqttException.java
@@ -24,6 +24,7 @@ public class MqttException extends Throwable {
   public final static int MQTT_INVALID_TOPIC_NAME = 0;
   public final static int MQTT_INVALID_TOPIC_FILTER = 1;
   public final static int MQTT_INFLIGHT_QUEUE_FULL = 2;
+  public final static int MQTT_INVALID_MESSAGE_ID = 3;
 
   private final int code;
 

--- a/src/main/java/io/vertx/mqtt/impl/MqttClientImpl.java
+++ b/src/main/java/io/vertx/mqtt/impl/MqttClientImpl.java
@@ -360,6 +360,14 @@ public class MqttClientImpl implements MqttClient {
    */
   @Override
   public Future<Integer> publish(String topic, Buffer payload, MqttQoS qosLevel, boolean isDup, boolean isRetain) {
+    return publish(-1, topic, payload, qosLevel, isDup, isRetain);
+  }
+
+  /**
+   * See {@link MqttClient#publish(int, String, Buffer, MqttQoS, boolean, boolean)} for more details
+   */
+  @Override
+  public Future<Integer> publish(int id, String topic, Buffer payload, MqttQoS qosLevel, boolean isDup, boolean isRetain) {
 
     if (MqttQoS.FAILURE == qosLevel) {
       throw new IllegalArgumentException("QoS level must be one of AT_MOST_ONCE, AT_LEAST_ONCE or EXACTLY_ONCE");
@@ -382,6 +390,25 @@ public class MqttClientImpl implements MqttClient {
         return ctx.failedFuture(exception);
       }
 
+      if (id < 0) {
+        id = nextMessageId();
+      } else {
+        switch (qosLevel) {
+          case AT_LEAST_ONCE:
+            if (qos1outbound.containsKey(id)) {
+              MqttException exception = new MqttException(MqttException.MQTT_INVALID_MESSAGE_ID, "");
+              return ctx.failedFuture(exception);
+            }
+            break;
+          case EXACTLY_ONCE:
+            if (qos2outbound.containsKey(id)) {
+              MqttException exception = new MqttException(MqttException.MQTT_INVALID_MESSAGE_ID, "");
+              return ctx.failedFuture(exception);
+            }
+            break;
+        }
+      }
+
       MqttFixedHeader fixedHeader = new MqttFixedHeader(
         MqttMessageType.PUBLISH,
         isDup,
@@ -390,7 +417,7 @@ public class MqttClientImpl implements MqttClient {
         0
       );
       ByteBuf buf = Unpooled.copiedBuffer(payload.getBytes());
-      variableHeader = new MqttPublishVariableHeader(topic, nextMessageId());
+      variableHeader = new MqttPublishVariableHeader(topic, id);
       publish = MqttMessageFactory.newMessage(fixedHeader, variableHeader, buf);
       switch (qosLevel) {
         case AT_LEAST_ONCE:
@@ -750,7 +777,7 @@ public class MqttClientImpl implements MqttClient {
    *
    * @param publishMessageId  identifier of the PUBLISH message to acknowledge
    */
-  private void publishRelease(int publishMessageId) {
+  public Future<Void> publishRelease(int publishMessageId) {
 
     MqttFixedHeader fixedHeader =
       new MqttFixedHeader(MqttMessageType.PUBREL, false, MqttQoS.AT_LEAST_ONCE, false, 0);
@@ -761,9 +788,12 @@ public class MqttClientImpl implements MqttClient {
     io.netty.handler.codec.mqtt.MqttMessage pubrel = MqttMessageFactory.newMessage(fixedHeader, variableHeader, null);
 
     synchronized (this) {
+      // todo: should check duplicates
       qos2outbound.put(publishMessageId, new ExpiringPacket(this::handlePubcompTimeout, publishMessageId));
     }
-    this.write(pubrel);
+    Future<Void> write = this.write(pubrel);
+
+    return write;
   }
 
   private void initChannel(NetSocketInternal sock) {

--- a/src/main/java/io/vertx/mqtt/impl/MqttEndpointImpl.java
+++ b/src/main/java/io/vertx/mqtt/impl/MqttEndpointImpl.java
@@ -59,6 +59,7 @@ import io.vertx.mqtt.messages.codes.MqttPubRelReasonCode;
 import io.vertx.mqtt.messages.codes.MqttSubAckReasonCode;
 import io.vertx.mqtt.messages.codes.MqttUnsubAckReasonCode;
 import io.vertx.mqtt.messages.codes.MqttAuthenticateReasonCode;
+import io.vertx.mqtt.messages.impl.MqttPublishMessageImpl;
 
 import javax.net.ssl.SSLSession;
 import java.util.Collections;
@@ -699,13 +700,8 @@ public class MqttEndpointImpl implements MqttEndpoint {
    */
   void handlePublish(io.vertx.mqtt.messages.MqttPublishMessage msg) {
 
-    synchronized (this.conn) {
-      if (this.publishHandler != null) {
-        this.publishHandler.handle(msg);
-      }
-
-      if (this.isPublishAutoAck) {
-
+    ((MqttPublishMessageImpl) msg).setAckCallback(() -> {
+      synchronized (this.conn) {
         switch (msg.qosLevel()) {
 
           case AT_LEAST_ONCE:
@@ -717,6 +713,18 @@ public class MqttEndpointImpl implements MqttEndpoint {
             break;
         }
       }
+    });
+
+    boolean ack;
+    synchronized (this.conn) {
+      if (this.publishHandler != null) {
+        this.publishHandler.handle(msg);
+      }
+      ack = isPublishAutoAck;
+    }
+
+    if (ack) {
+      msg.ack();
     }
   }
 

--- a/src/test/java/io/vertx/mqtt/test/client/MqttClientQoSTest.java
+++ b/src/test/java/io/vertx/mqtt/test/client/MqttClientQoSTest.java
@@ -1,0 +1,226 @@
+package io.vertx.mqtt.test.client;
+
+import io.netty.handler.codec.mqtt.MqttQoS;
+import io.vertx.core.Vertx;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.ext.unit.junit.VertxUnitRunner;
+import io.vertx.mqtt.*;
+import io.vertx.mqtt.messages.MqttPublishMessage;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.BooleanSupplier;
+
+import static org.junit.Assert.*;
+
+@RunWith(VertxUnitRunner.class)
+public class MqttClientQoSTest {
+
+  private Vertx vertx;
+  private MqttServer server;
+  private MqttClient client;
+
+  @Before
+  public void before() {
+    vertx = Vertx.vertx();
+    server = MqttServer.create(vertx);
+  }
+
+  @After
+  public void after() {
+    server.close().await();
+    vertx.close().await();
+  }
+
+  @Test
+  public void testQoS1SendDuplicateShouldFail() throws Exception {
+    testSendDuplicateShouldFail(MqttQoS.AT_LEAST_ONCE);
+  }
+
+  @Test
+  public void testQoS2SendDuplicateShouldFail() throws Exception {
+    testSendDuplicateShouldFail(MqttQoS.EXACTLY_ONCE);
+  }
+
+  /**
+   * The client should not accept to send a PUBLISH message with a duplicate ID.
+   */
+  private void testSendDuplicateShouldFail(MqttQoS qos) throws Exception {
+    AtomicInteger receivedCount = new AtomicInteger();
+    server.endpointHandler(endpoint -> {
+      endpoint.publishHandler(msg -> {
+        receivedCount.incrementAndGet();
+      });
+      endpoint.accept();
+    });
+    startServer();
+    client = MqttClient.create(vertx, new MqttClientOptions().setAutoAck(false).setAckTimeout(10));
+    client.connect(MqttServerOptions.DEFAULT_PORT, MqttServerOptions.DEFAULT_HOST).await();
+    Integer id = client.publish("test", Buffer.buffer(), qos, false, false).await();
+    try {
+      client.publish(id, "test", Buffer.buffer(), qos, false, false).await();
+      fail();
+    } catch (Throwable e) {
+      MqttException mqttEx = (MqttException) e;
+      assertEquals(MqttException.MQTT_INVALID_MESSAGE_ID, mqttEx.code());
+    }
+    assertTrue(() -> receivedCount.get() < 2, Duration.ofSeconds(2));
+  }
+
+  @Test
+  public void testQoS1SendExpiredDuplicate() throws Exception {
+    testSendExpiredDuplicate(MqttQoS.AT_LEAST_ONCE);
+  }
+
+  @Test
+  public void testQoS2SendExpiredDuplicate() throws Exception {
+    testSendExpiredDuplicate(MqttQoS.EXACTLY_ONCE);
+  }
+
+  /**
+   * It should be possible to resent an expired PUBLISH message with the client (retry).
+   * <p/>
+   * Simulates the use case of PUBLISH message loss or PUBACK/PUBREC loss:
+   * - client sends PUBLISH
+   * - we pretend server does not receive the message, the client expires the message ID
+   * - client sends PUBLISH
+   * - server sends PUBACK/PUBREC
+   * - QoS2: client sends PUBREL
+   * - QoS2: server sends PUBCOMP
+   */
+  private void testSendExpiredDuplicate(MqttQoS qos) throws Exception {
+    AtomicInteger receivedCount = new AtomicInteger();
+    server.endpointHandler(endpoint -> {
+      endpoint.publishHandler(msg -> {
+        switch (receivedCount.getAndIncrement()) {
+          case 1:
+            msg.ack();
+            break;
+        }
+      });
+      endpoint.publishReleaseHandler(msgId -> endpoint.publishComplete(msgId));
+      endpoint.accept();
+    });
+    startServer();
+    client = MqttClient.create(vertx, new MqttClientOptions().setAutoAck(false).setAckTimeout(1));
+    List<Integer> completionIds = Collections.synchronizedList(new ArrayList<>());
+    List<Integer> expiredIds = Collections.synchronizedList(new ArrayList<>());
+    client.publishCompletionHandler(completionIds::add);
+    client.publishCompletionExpirationHandler(expiredIds::add);
+    client.connect(MqttServerOptions.DEFAULT_PORT, MqttServerOptions.DEFAULT_HOST).await();
+    Integer id = client.publish("test", Buffer.buffer(), qos, false, false).await();
+    assertWaitUntil(() -> expiredIds.size() == 1);
+    Integer newId = client.publish(id, "test", Buffer.buffer(), qos, false, false).await();
+    assertEquals(id, newId);
+    assertWaitUntil(() -> completionIds.size() == 1);
+  }
+
+  @Test
+  public void testQos1UnknownCompletion() throws Exception {
+    testUnknownCompletion(MqttQoS.AT_LEAST_ONCE);
+  }
+
+  @Test
+  public void testQos2UnknownCompletion() throws Exception {
+    testUnknownCompletion(MqttQoS.EXACTLY_ONCE);
+  }
+
+  /**
+   * Simple test checking that receiving an unknown message ID from server triggers
+   * the unknown packet id handler.
+   */
+  private void testUnknownCompletion(MqttQoS qos) throws Exception {
+    AtomicReference<MqttPublishMessage> msgRef = new AtomicReference<>();
+    server.endpointHandler(endpoint -> {
+      endpoint.publishHandler(msg -> msgRef.set(msg));
+      endpoint.accept();
+    });
+    startServer();
+    client = MqttClient.create(vertx, new MqttClientOptions().setAutoAck(false).setAckTimeout(1));
+    List<Integer> expiredIds = Collections.synchronizedList(new ArrayList<>());
+    List<Integer> unknownIds = Collections.synchronizedList(new ArrayList<>());
+    client.publishCompletionExpirationHandler(expiredIds::add);
+    client.publishCompletionUnknownPacketIdHandler(unknownIds::add);
+    client.connect(MqttServerOptions.DEFAULT_PORT, MqttServerOptions.DEFAULT_HOST).await();
+    Integer id = client.publish("test", Buffer.buffer(), qos, false, false).await();
+    assertWaitUntil(() -> expiredIds.size() == 1);
+    assertEquals(0, unknownIds.size());
+    assertSame(id, msgRef.get().messageId());
+    msgRef.get().ack();
+    assertWaitUntil(() -> unknownIds.size() == 1);
+  }
+
+  /**
+   * It should be possible to resent an expired PUBREL message with the client (retry).
+   * <p/>
+   * This simulates the use case of PUBREL message loss or PUBCOMP loss:
+   * - client sends PUBLISH
+   * - server sends PUBREC
+   * - client sends PUBREL
+   * - client PUBREL expires and retransmit it
+   * - server sends PUBCOMP
+   */
+  @Test
+  public void testQos2CompRetransmit() throws Exception {
+    AtomicInteger publishCount = new AtomicInteger();
+    AtomicInteger releaseCount = new AtomicInteger();
+    server.endpointHandler(endpoint -> {
+      endpoint.publishHandler(msg -> {
+        publishCount.incrementAndGet();
+        msg.ack();
+      });
+      endpoint.publishReleaseHandler(msgId -> {
+        switch (releaseCount.getAndIncrement()) {
+          case 1:
+            endpoint.publishComplete(msgId);
+            break;
+        }
+      });
+      endpoint.accept();
+    });
+    startServer();
+    client = MqttClient.create(vertx, new MqttClientOptions().setAutoAck(false).setAckTimeout(1));
+    List<Integer> completionIds = Collections.synchronizedList(new ArrayList<>());
+    List<Integer> expiredIds = Collections.synchronizedList(new ArrayList<>());
+    client.publishCompletionHandler(completionIds::add);
+    client.publishCompletionExpirationHandler(expiredIds::add);
+    client.connect(MqttServerOptions.DEFAULT_PORT, MqttServerOptions.DEFAULT_HOST).await();
+    Integer id = client.publish("test", Buffer.buffer(), MqttQoS.EXACTLY_ONCE, false, false).await();
+    assertWaitUntil(() -> expiredIds.size() == 1);
+    assertWaitUntil(() -> publishCount.get() == 1);
+    assertWaitUntil(() -> releaseCount.get() == 1);
+    client.publishRelease(id).await();
+    assertWaitUntil(() -> releaseCount.get() == 2);
+    assertWaitUntil(() -> completionIds.size() == 1);
+    assertTrue(() -> expiredIds.size() == 1 && publishCount.get() == 1, Duration.ofSeconds(1));
+  }
+
+  private void startServer() throws Exception {
+    server.listen().await(20, TimeUnit.SECONDS);
+  }
+
+  private void assertWaitUntil(BooleanSupplier cond) throws Exception {
+    long now = System.currentTimeMillis();
+    while (!cond.getAsBoolean()) {
+      Assert.assertTrue(System.currentTimeMillis() - now < 20_000);
+      Thread.sleep(10);
+    }
+  }
+
+  private void assertTrue(BooleanSupplier cond, Duration duration) throws Exception {
+    long now = System.currentTimeMillis();
+    while (System.currentTimeMillis() - now < duration.toMillis()) {
+      Assert.assertTrue(cond.getAsBoolean());
+    }
+  }
+}

--- a/src/test/java/module-info.java
+++ b/src/test/java/module-info.java
@@ -30,4 +30,6 @@ open module io.vertx.tests.mqtt {
   requires org.eclipse.paho.client.mqttv3;
   requires org.eclipse.paho.mqttv5.client;
   requires testcontainers;
+  requires testcontainers.junit.jupiter;
+  requires hamcrest.core;
 }


### PR DESCRIPTION
Motivation:

For QoS > 0, the client needs to re-send PUB/PUBREL messages with an existing ID.

The client is currently only capable of sending PUB/PUBREL messages with the autoassigned identifier.

When a message expires, the sender should be capable to resend the same message specifying the ID since the message is a retransmission.

Changes:

Overload MqttClient#publish MqttClient#publishRelease methods with a message identifier to implement PUB/PUBREL retransmission by the client.
