### PR TITLE
Fix MqttEndpoint auth for partial CONNECT credentials (4.x branch)

### DIFF
--- a/src/main/java/io/vertx/mqtt/MqttAuth.java
+++ b/src/main/java/io/vertx/mqtt/MqttAuth.java
@@ -31,8 +31,8 @@ public class MqttAuth {
   /**
    * Constructor
    *
-   * @param username MQTT client username
-   * @param password MQTT client password
+   * @param username MQTT client username, or {@code null} when not provided
+   * @param password MQTT client password, or {@code null} when not provided
    */
   public MqttAuth(String username, String password) {
     this.username = username;
@@ -50,14 +50,14 @@ public class MqttAuth {
   }
 
   /**
-   * @return the username provided by the remote MQTT client
+   * @return the username provided by the remote MQTT client, or {@code null} when not provided
    */
   public String getUsername() {
     return this.username;
   }
 
   /**
-   * @return the password provided by the remote MQTT client
+   * @return the password provided by the remote MQTT client, or {@code null} when not provided
    */
   public String getPassword() {
     return this.password;

--- a/src/main/java/io/vertx/mqtt/MqttEndpoint.java
+++ b/src/main/java/io/vertx/mqtt/MqttEndpoint.java
@@ -105,7 +105,8 @@ public interface MqttEndpoint {
   String clientIdentifier();
 
   /**
-   * @return the Authentication information as provided by the remote MQTT client
+   * @return the Authentication information as provided by the remote MQTT client,
+   *         or {@code null} when neither username nor password information is available
    */
   @CacheReturn
   MqttAuth auth();

--- a/src/main/java/io/vertx/mqtt/impl/MqttServerConnection.java
+++ b/src/main/java/io/vertx/mqtt/impl/MqttServerConnection.java
@@ -30,6 +30,7 @@ import io.netty.handler.codec.mqtt.MqttVersion;
 import io.netty.handler.timeout.IdleState;
 import io.netty.handler.timeout.IdleStateEvent;
 import io.netty.handler.timeout.IdleStateHandler;
+import io.netty.util.CharsetUtil;
 import io.vertx.core.Handler;
 import io.vertx.core.MultiMap;
 import io.vertx.core.VertxException;
@@ -261,11 +262,15 @@ public class MqttServerConnection {
         msg.payload().willProperties());
 
     // retrieve authorization information from CONNECT message
-    MqttAuth auth = (msg.variableHeader().hasUserName() &&
-      msg.variableHeader().hasPassword()) ?
-      new MqttAuth(
-        msg.payload().userName(),
-        msg.payload().password()) : null;
+    boolean hasUsername = msg.variableHeader().hasUserName();
+    boolean hasPassword = msg.variableHeader().hasPassword();
+    MqttAuth auth = null;
+    if (hasUsername ||
+      (hasPassword && msg.variableHeader().version() == MqttVersion.MQTT_5.protocolLevel())) {
+      auth = new MqttAuth(
+        hasUsername ? msg.payload().userName() : null,
+        hasPassword ? new String(msg.payload().passwordInBytes(), CharsetUtil.UTF_8) : null);
+    }
 
     // check if remote MQTT client didn't specify a client-id
     boolean isZeroBytes = (msg.payload().clientIdentifier() == null) ||

--- a/src/test/java/io/vertx/mqtt/test/server/Mqtt5ServerConnectionTest.java
+++ b/src/test/java/io/vertx/mqtt/test/server/Mqtt5ServerConnectionTest.java
@@ -158,6 +158,46 @@ public class Mqtt5ServerConnectionTest extends MqttServerBaseTest {
   }
 
   @Test
+  public void acceptedUsernameWithoutPassword(TestContext context) {
+
+    this.expectedReturnCode = MqttConnectReturnCode.CONNECTION_ACCEPTED;
+
+    try {
+      MemoryPersistence persistence = new MemoryPersistence();
+      MqttConnectionOptions options = new MqttConnectionOptions();
+      options.setUserName(MQTT_USERNAME);
+      MqttClient client = new MqttClient(String.format("tcp://%s:%d", MQTT_SERVER_HOST, MQTT_SERVER_PORT), "12345", persistence);
+      client.connect(options);
+
+      context.assertNotNull(endpoint.auth());
+      context.assertEquals(MQTT_USERNAME, endpoint.auth().getUsername());
+      context.assertNull(endpoint.auth().getPassword());
+    } catch (MqttException e) {
+      context.fail(e);
+    }
+  }
+
+  @Test
+  public void acceptedPasswordWithoutUsername(TestContext context) {
+
+    this.expectedReturnCode = MqttConnectReturnCode.CONNECTION_ACCEPTED;
+
+    try {
+      MemoryPersistence persistence = new MemoryPersistence();
+      MqttConnectionOptions options = new MqttConnectionOptions();
+      options.setPassword(MQTT_PASSWORD.getBytes(StandardCharsets.UTF_8));
+      MqttClient client = new MqttClient(String.format("tcp://%s:%d", MQTT_SERVER_HOST, MQTT_SERVER_PORT), "12345", persistence);
+      client.connect(options);
+
+      context.assertNotNull(endpoint.auth());
+      context.assertNull(endpoint.auth().getUsername());
+      context.assertEquals(MQTT_PASSWORD, endpoint.auth().getPassword());
+    } catch (MqttException e) {
+      context.fail(e);
+    }
+  }
+
+  @Test
   public void refusedNotAuthorized(TestContext context) {
 
     this.expectedReturnCode = MqttConnectReturnCode.CONNECTION_REFUSED_NOT_AUTHORIZED_5;

--- a/src/test/java/io/vertx/mqtt/test/server/MqttServerConnectionTest.java
+++ b/src/test/java/io/vertx/mqtt/test/server/MqttServerConnectionTest.java
@@ -142,6 +142,26 @@ public class MqttServerConnectionTest extends MqttServerBaseTest {
   }
 
   @Test
+  public void acceptedUsernameWithoutPassword(TestContext context) {
+
+    this.expectedReturnCode = MqttConnectReturnCode.CONNECTION_ACCEPTED;
+
+    try {
+      MemoryPersistence persistence = new MemoryPersistence();
+      MqttConnectOptions options = new MqttConnectOptions();
+      options.setUserName(MQTT_USERNAME);
+      MqttClient client = new MqttClient(String.format("tcp://%s:%d", MQTT_SERVER_HOST, MQTT_SERVER_PORT), "12345", persistence);
+      client.connect(options);
+
+      context.assertNotNull(endpoint.auth());
+      context.assertEquals(MQTT_USERNAME, endpoint.auth().getUsername());
+      context.assertNull(endpoint.auth().getPassword());
+    } catch (MqttException e) {
+      context.fail(e);
+    }
+  }
+
+  @Test
   public void refusedNotAuthorized(TestContext context) {
 
     this.expectedReturnCode = MqttConnectReturnCode.CONNECTION_REFUSED_NOT_AUTHORIZED;


### PR DESCRIPTION
Motivation:

Backport of #288 for the 4.x branch.

This applies the same `MqttEndpoint.auth()` mapping fix from master for username-only CONNECT packets and MQTT 5 password-only CONNECT packets.

Conformance:
I have signed the EcA