### PR TITLE
Fix MqttServerOptions WebSocket no-context copy

### DIFF
--- a/src/main/java/io/vertx/mqtt/MqttServerOptions.java
+++ b/src/main/java/io/vertx/mqtt/MqttServerOptions.java
@@ -134,7 +134,7 @@ public class MqttServerOptions extends NetServerOptions {
     this.perMessageWebSocketCompressionSupported = other.perMessageWebSocketCompressionSupported;
     this.webSocketCompressionLevel = other.webSocketCompressionLevel;
     this.webSocketAllowServerNoContext = other.webSocketAllowServerNoContext;
-    this.webSocketPreferredClientNoContext = other.webSocketAllowServerNoContext;
+    this.webSocketPreferredClientNoContext = other.webSocketPreferredClientNoContext;
   }
 
   @Override

--- a/src/test/java/io/vertx/mqtt/test/server/MqttServerOptionsTest.java
+++ b/src/test/java/io/vertx/mqtt/test/server/MqttServerOptionsTest.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2026 Red Hat Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.vertx.mqtt.test.server;
+
+import io.vertx.mqtt.MqttServerOptions;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class MqttServerOptionsTest {
+
+  @Test
+  public void testCopyWebSocketNoContextOptions() {
+    boolean allowServerNoContext = false;
+    boolean preferredClientNoContext = true;
+    MqttServerOptions options = new MqttServerOptions()
+      .setWebSocketAllowServerNoContext(allowServerNoContext)
+      .setWebSocketPreferredClientNoContext(preferredClientNoContext);
+
+    MqttServerOptions copy = new MqttServerOptions(options);
+
+    assertEquals(allowServerNoContext, copy.isWebSocketAllowServerNoContext());
+    assertEquals(preferredClientNoContext, copy.isWebSocketPreferredClientNoContext());
+
+    boolean otherAllowServerNoContext = true;
+    boolean otherPreferredClientNoContext = false;
+    MqttServerOptions otherOptions = new MqttServerOptions()
+      .setWebSocketAllowServerNoContext(otherAllowServerNoContext)
+      .setWebSocketPreferredClientNoContext(otherPreferredClientNoContext);
+
+    MqttServerOptions otherCopy = new MqttServerOptions(otherOptions);
+
+    assertEquals(otherAllowServerNoContext, otherCopy.isWebSocketAllowServerNoContext());
+    assertEquals(otherPreferredClientNoContext, otherCopy.isWebSocketPreferredClientNoContext());
+  }
+}


### PR DESCRIPTION
Motivation:

`MqttServerOptions` copied `webSocketPreferredClientNoContext` from the wrong field in its copy constructor. This fixes the copy and adds a small regression test.

Conformance:

I have signed the ECA