### PR TITLE
Expose SSL options update on MQTT server (5.1 branch)

### DIFF
--- a/src/main/java/io/vertx/mqtt/MqttServer.java
+++ b/src/main/java/io/vertx/mqtt/MqttServer.java
@@ -21,6 +21,7 @@ import io.vertx.codegen.annotations.VertxGen;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
 import io.vertx.core.Vertx;
+import io.vertx.core.net.ServerSSLOptions;
 import io.vertx.mqtt.impl.MqttServerImpl;
 
 /**
@@ -100,6 +101,38 @@ public interface MqttServer {
    */
   @Fluent
   MqttServer exceptionHandler(Handler<Throwable> handler);
+
+  /**
+   * Update the server with new SSL {@code options}, the update happens if the options object is valid and different
+   * from the existing options object.
+   * <p>
+   * This is equivalent to calling {@link #updateSSLOptions(ServerSSLOptions, boolean)} with {@code force} set to
+   * {@code false}.
+   * <p>
+   * The boolean succeeded future result indicates whether the update occurred.
+   *
+   * @param options the new SSL options
+   * @return a future signaling the update success
+   */
+  default Future<Boolean> updateSSLOptions(ServerSSLOptions options) {
+    return updateSSLOptions(options, false);
+  }
+
+  /**
+   * Update the server with new SSL {@code options}, the update happens if the options object is valid and different
+   * from the existing options object.
+   * <p>
+   * The {@code options} object is compared using its {@code equals} method against the existing options to prevent
+   * an update when the objects are equal since loading options can be costly. When options are equal, setting
+   * {@code force} to {@code true} forces the update.
+   * <p>
+   * The boolean succeeded future result indicates whether the update occurred.
+   *
+   * @param options the new SSL options
+   * @param force force the update when options are equal
+   * @return a future signaling the update success
+   */
+  Future<Boolean> updateSSLOptions(ServerSSLOptions options, boolean force);
 
   /**
    * The actual port the server is listening on. This is useful if you bound the server specifying 0 as port number

--- a/src/main/java/io/vertx/mqtt/impl/MqttServerImpl.java
+++ b/src/main/java/io/vertx/mqtt/impl/MqttServerImpl.java
@@ -45,6 +45,7 @@ import io.vertx.core.internal.net.NetSocketInternal;
 import io.vertx.core.internal.logging.Logger;
 import io.vertx.core.internal.logging.LoggerFactory;
 import io.vertx.core.net.NetServer;
+import io.vertx.core.net.ServerSSLOptions;
 import io.vertx.mqtt.MqttEndpoint;
 import io.vertx.mqtt.MqttServer;
 import io.vertx.mqtt.MqttServerOptions;
@@ -126,6 +127,11 @@ public class MqttServerImpl implements MqttServer {
   public synchronized MqttServer exceptionHandler(Handler<Throwable> handler) {
     exceptionHandler = handler;
     return this;
+  }
+
+  @Override
+  public Future<Boolean> updateSSLOptions(ServerSSLOptions options, boolean force) {
+    return server.updateSSLOptions(options, force);
   }
 
   @Override

--- a/src/test/java/io/vertx/mqtt/test/server/MqttServerSslTest.java
+++ b/src/test/java/io/vertx/mqtt/test/server/MqttServerSslTest.java
@@ -18,6 +18,7 @@ package io.vertx.mqtt.test.server;
 
 import io.vertx.core.internal.logging.Logger;
 import io.vertx.core.internal.logging.LoggerFactory;
+import io.vertx.core.net.ServerSSLOptions;
 import io.vertx.ext.unit.Async;
 import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
@@ -90,6 +91,65 @@ public class MqttServerSslTest extends MqttServerBaseTest {
     } catch (Exception e1) {
       e1.printStackTrace();
       context.assertTrue(false);
+    }
+  }
+
+  @Test
+  public void updateSslOptionsUsesNewServerSslOptions(TestContext context) throws Exception {
+
+    ServerSSLOptions updatedOptions = new ServerSSLOptions()
+      .setKeyCertOptions(Cert.SERVER_PEM_OTHER_CA.get());
+
+    // Different SSL options update the server.
+    Async update = context.async();
+    this.mqttServer.updateSSLOptions(updatedOptions).onComplete(context.asyncAssertSuccess(updated -> {
+      context.assertTrue(updated);
+      update.complete();
+    }));
+    update.awaitSuccess(15000);
+
+    connectWithOtherCaTrustStore(context);
+
+    // Equal SSL options do not update the server.
+    Async sameOptions = context.async();
+    this.mqttServer.updateSSLOptions(updatedOptions).onComplete(context.asyncAssertSuccess(updated -> {
+      context.assertFalse(updated);
+      sameOptions.complete();
+    }));
+    sameOptions.awaitSuccess(15000);
+
+    // Equal SSL options update the server when forced.
+    Async forcedUpdate = context.async();
+    this.mqttServer.updateSSLOptions(updatedOptions, true).onComplete(context.asyncAssertSuccess(updated -> {
+      context.assertTrue(updated);
+      forcedUpdate.complete();
+    }));
+    forcedUpdate.awaitSuccess(15000);
+  }
+
+  private void connectWithOtherCaTrustStore(TestContext context) throws Exception {
+
+    MemoryPersistence persistence = new MemoryPersistence();
+    try (MqttClient client = new MqttClient(
+      String.format("ssl://%s:%d", MQTT_SERVER_HOST, MQTT_SERVER_TLS_PORT),
+      "update-ssl-options",
+      persistence)) {
+      MqttConnectOptions options = new MqttConnectOptions();
+      options.setSocketFactory(this.getSocketFactory("/tls/server-truststore-other-ca-fallback.jks", null));
+
+      boolean connected = false;
+      Throwable rejection = null;
+      try {
+        client.connect(options);
+        connected = client.isConnected();
+        rejection = this.rejection;
+      } finally {
+        if (client.isConnected()) {
+          client.disconnect();
+        }
+      }
+      context.assertTrue(connected);
+      context.assertNull(rejection);
     }
   }
 


### PR DESCRIPTION
Motivation:

Backport of #297 for the 5.1 branch.

This applies the same `MqttServer.updateSSLOptions` support from master.

Conformance:

I have signed the ECA