### PR TITLE
Fix MQTT WebSocket query string handling

### DIFF
--- a/src/main/asciidoc/index.adoc
+++ b/src/main/asciidoc/index.adoc
@@ -92,14 +92,15 @@ The MQTT server is started passing the Vert.x instance as usual and the above MQ
 
 If you want to support connections via WebSockets, you can enable this via {@link io.vertx.mqtt.MqttServerOptions},
 too. By passing `true` to {@link io.vertx.mqtt.MqttServerOptions#setUseWebSocket(boolean)}, it will listen for
-websocket connections on the path `/mqtt`.
+WebSocket connections on the path `/mqtt`. The request URI can include a query string, for example
+`/mqtt?client=web`, and the full HTTP request URI is available from {@link io.vertx.mqtt.MqttEndpoint#httpRequestURI()}.
 
 As with other setup configurations, the resulting endpoint connections and related disconnection are managed the same
 way as regular connections.
 
 [source,$lang]
 ----
-{@link examples.VertxMqttServerExamples#example11}
+{@link examples.VertxMqttServerExamples#example12}
 ----
 
 === Handling client subscription/unsubscription request

--- a/src/main/java/io/vertx/mqtt/impl/MqttServerImpl.java
+++ b/src/main/java/io/vertx/mqtt/impl/MqttServerImpl.java
@@ -18,14 +18,22 @@ package io.vertx.mqtt.impl;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.ChannelDuplexHandler;
+import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInboundHandlerAdapter;
 import io.netty.channel.ChannelPipeline;
 import io.netty.handler.codec.MessageToMessageDecoder;
 import io.netty.handler.codec.MessageToMessageEncoder;
 import io.netty.handler.codec.compression.ZlibCodecFactory;
+import io.netty.handler.codec.http.DefaultFullHttpResponse;
+import io.netty.handler.codec.http.FullHttpRequest;
+import io.netty.handler.codec.http.FullHttpResponse;
 import io.netty.handler.codec.http.HttpObjectAggregator;
+import io.netty.handler.codec.http.HttpResponseStatus;
 import io.netty.handler.codec.http.HttpServerCodec;
+import io.netty.handler.codec.http.HttpUtil;
 import io.netty.handler.codec.http.websocketx.BinaryWebSocketFrame;
+import io.netty.handler.codec.http.websocketx.WebSocketServerProtocolConfig;
 import io.netty.handler.codec.http.websocketx.WebSocketServerProtocolHandler;
 import io.netty.handler.codec.http.websocketx.extensions.WebSocketServerExtensionHandler;
 import io.netty.handler.codec.http.websocketx.extensions.WebSocketServerExtensionHandshaker;
@@ -62,6 +70,7 @@ import static io.vertx.mqtt.MqttServerOptions.MQTT_SUBPROTOCOL_CSV_LIST;
 public class MqttServerImpl implements MqttServer {
 
   private static final Logger log = LoggerFactory.getLogger(MqttServerImpl.class);
+  private static final String MQTT_WEBSOCKET_PATH = "/mqtt";
 
   private final VertxInternal vertx;
   private final NetServer server;
@@ -194,6 +203,30 @@ public class MqttServerImpl implements MqttServer {
     }
   }
 
+  private static class WebSocketPathHandler extends ChannelInboundHandlerAdapter {
+
+    @Override
+    public void channelRead(ChannelHandlerContext ctx, Object msg) throws Exception {
+      if (msg instanceof FullHttpRequest) {
+        FullHttpRequest request = (FullHttpRequest) msg;
+        if (!isWebSocketPath(request.uri())) {
+          FullHttpResponse response = new DefaultFullHttpResponse(
+            request.protocolVersion(), HttpResponseStatus.NOT_FOUND);
+          HttpUtil.setContentLength(response, 0);
+          ctx.writeAndFlush(response).addListener(ChannelFutureListener.CLOSE);
+          ReferenceCountUtil.release(request);
+          return;
+        }
+        ctx.pipeline().remove(this);
+      }
+      ctx.fireChannelRead(msg);
+    }
+
+    private boolean isWebSocketPath(String uri) {
+      return MQTT_WEBSOCKET_PATH.equals(uri) || uri.startsWith(MQTT_WEBSOCKET_PATH + "?");
+    }
+  }
+
   private void initChannel(ChannelPipeline pipeline) {
 
     pipeline.addBefore("handler", "mqttEncoder", MqttEncoder.INSTANCE);
@@ -223,17 +256,30 @@ public class MqttServerImpl implements MqttServer {
 
       pipeline.addBefore("mqttEncoder", "httpServerCodec", new HttpServerCodec());
       pipeline.addAfter("httpServerCodec", "aggregator", new HttpObjectAggregator(maxFrameSize));
+      pipeline.addAfter("aggregator", "webSocketPathHandler", new WebSocketPathHandler());
 
       List<WebSocketServerExtensionHandshaker> extensionHandshakers = createExtensionHandshakers();
+      String webSocketHandlerBase = "webSocketPathHandler";
 
       if (!extensionHandshakers.isEmpty()) {
         WebSocketServerExtensionHandler extensionHandler = new WebSocketServerExtensionHandler(
           extensionHandshakers.toArray(new WebSocketServerExtensionHandshaker[0]));
-        pipeline.addAfter("aggregator", "webSocketExtensionHandler", extensionHandler);
+        pipeline.addAfter(webSocketHandlerBase, "webSocketExtensionHandler", extensionHandler);
+        webSocketHandlerBase = "webSocketExtensionHandler";
       }
 
-      pipeline.addAfter("webSocketExtensionHandler", "webSocketHandler",
-        new WebSocketServerProtocolHandler("/mqtt", MQTT_SUBPROTOCOL_CSV_LIST, !extensionHandshakers.isEmpty(), maxFrameSize, 10000L));
+      // Netty's checkStartsWith(true) also accepts sub-paths; only /mqtt and /mqtt?... are valid here.
+      pipeline.addAfter(webSocketHandlerBase, "webSocketHandler",
+        new WebSocketServerProtocolHandler(WebSocketServerProtocolConfig.newBuilder()
+          .websocketPath(MQTT_WEBSOCKET_PATH)
+          .subprotocols(MQTT_SUBPROTOCOL_CSV_LIST)
+          .checkStartsWith(true)
+          .handshakeTimeoutMillis(10000L)
+          .maxFramePayloadLength(maxFrameSize)
+          .allowMaskMismatch(false)
+          .allowExtensions(!extensionHandshakers.isEmpty())
+          .dropPongFrames(true)
+          .build()));
 
       pipeline.addAfter("webSocketHandler", "bytebuf2wsEncoder", new ByteBufToWebSocketFrameEncoder());
       pipeline.addAfter("bytebuf2wsEncoder", "ws2bytebufDecoder", new WebSocketFrameToByteBufDecoder());

--- a/src/test/java/io/vertx/mqtt/test/server/MqttServerWebSocketTest.java
+++ b/src/test/java/io/vertx/mqtt/test/server/MqttServerWebSocketTest.java
@@ -19,6 +19,8 @@ package io.vertx.mqtt.test.server;
 import io.vertx.core.MultiMap;
 import io.vertx.core.Vertx;
 import io.vertx.core.VertxOptions;
+import io.vertx.core.http.HttpClient;
+import io.vertx.core.http.HttpMethod;
 import io.vertx.core.impl.ConcurrentHashSet;
 import io.vertx.core.logging.Logger;
 import io.vertx.core.logging.LoggerFactory;
@@ -182,5 +184,77 @@ public class MqttServerWebSocketTest {
 
 
 
+  }
+
+  @Test
+  public void testWebSocketPathWithQueryString(TestContext context) {
+    MqttServer server = MqttServer.create(this.vertx, new MqttServerOptions()
+      .setHost(MQTT_SERVER_HOST)
+      .setPort(0)
+      .setUseWebSocket(true));
+    Async done = context.async();
+    server.endpointHandler(endpoint -> {
+      context.assertEquals("/mqtt?auth=token", endpoint.httpRequestURI());
+      done.complete();
+      endpoint.accept(false);
+    });
+    Async listen = context.async();
+    server.listen(context.asyncAssertSuccess(s -> listen.complete()));
+    listen.awaitSuccess(15_000);
+    MemoryPersistence persistence = new MemoryPersistence();
+    String serverUri = String.format("ws://%s:%d/mqtt?auth=token", MQTT_SERVER_HOST, server.actualPort());
+    try (MqttClient client = new MqttClient(serverUri, "query-string", persistence)) {
+      client.connect();
+      client.disconnect();
+    } catch (MqttException e) {
+      context.fail(e);
+    }
+    done.awaitSuccess(15_000);
+  }
+
+  @Test
+  public void testInvalidWebSocketPathRejected(TestContext context) {
+    MqttServer server = MqttServer.create(this.vertx, new MqttServerOptions()
+      .setHost(MQTT_SERVER_HOST)
+      .setPort(0)
+      .setUseWebSocket(true));
+    server.endpointHandler(endpoint ->
+      context.fail("Endpoint handler should not be called for invalid WebSocket path"));
+    Async listen = context.async();
+    server.listen(context.asyncAssertSuccess(s -> listen.complete()));
+    listen.awaitSuccess(15_000);
+
+    HttpClient client = this.vertx.createHttpClient();
+    try {
+      assertInvalidWebSocketPathRejected(context, client, server.actualPort(), "/mqttfoo?auth=token");
+      assertInvalidWebSocketPathRejected(context, client, server.actualPort(), "/mqtt/foo?auth=token");
+    } finally {
+      client.close();
+    }
+  }
+
+  private void assertInvalidWebSocketPathRejected(TestContext context, HttpClient client, int port, String requestUri) {
+    Async done = context.async();
+    client.request(HttpMethod.GET, port, MQTT_SERVER_HOST, requestUri)
+      .compose(request -> request
+        .setTimeout(5_000)
+        .putHeader("Connection", "Upgrade")
+        .putHeader("Upgrade", "websocket")
+        .putHeader("Sec-WebSocket-Key", "dGhlIHNhbXBsZSBub25jZQ==")
+        .putHeader("Sec-WebSocket-Version", "13")
+        .putHeader("Sec-WebSocket-Protocol", "mqtt")
+        .send())
+      .onComplete(response -> {
+        try {
+          if (response.failed()) {
+            context.fail(response.cause());
+            return;
+          }
+          context.assertEquals(404, response.result().statusCode());
+        } finally {
+          done.complete();
+        }
+      });
+    done.awaitSuccess(15_000);
   }
 }


### PR DESCRIPTION
Motivation:

Fixes #221.

MQTT over WebSocket currently accepts only the exact `/mqtt` request URI, so clients using a query string such as `ws://host:port/mqtt?auth=token` fail the WebSocket handshake.

This change accepts `/mqtt` with an optional query string while preserving the original HTTP request URI in `MqttEndpoint#httpRequestURI()`.

Non-matching WebSocket paths are still rejected before reaching the MQTT endpoint handler.

Regression tests and the WebSocket documentation were updated.

Conformance:

I have signed the ECA
