### PR TITLE
Server have to disconnect the client at least at keepalive * 1.5

### DIFF
--- a/src/test/java/io/vertx/mqtt/test/server/MqttServerNetworkIssueTest.java
+++ b/src/test/java/io/vertx/mqtt/test/server/MqttServerNetworkIssueTest.java
@@ -110,10 +110,12 @@ public class MqttServerNetworkIssueTest extends MqttServerBaseTest {
 
       async.await();
 
+      // the connection should be dropped within a 1 second window after the expected keep alive timeout
       long elapsed = ended - started;
-      // consider a range of 500 ms
-      context.assertTrue(elapsed > (timeout * 1000 - 500) && elapsed < (timeout * 1000 + 500),
-        elapsed + " > " + ((timeout * 1000 - 500)) + " && " + elapsed + " < " + (timeout * 1000 + 500) + " != true");
+      long expectedMin = timeout * 1000L;
+      long expectedMax = expectedMin + 1000L;
+      context.assertTrue(elapsed >= expectedMin && elapsed <= expectedMax,
+        String.format("elapsed %d ms is not in the expected range [%d, %d] ms", elapsed, expectedMin, expectedMax));
 
     } catch (MqttException e) {
       context.fail(e);


### PR DESCRIPTION
The disconnection due to miss keepalive have to happen after (at least) 1.5 * keepalive interval but the test check an interval between -500 msec e +500 msec the disconnection instant expected.

Change to 0 to +1sec (I hope to reduce also flaky test)